### PR TITLE
fix: handle missing `participant_address`

### DIFF
--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -59,7 +59,7 @@ const fetchMeasurements = async (web3Storage, cid) => {
 }
 
 export const parseParticipantAddress = filWalletAddress => {
-  if (filWalletAddress.startsWith('f1') || filWalletAddress.startsWith('t1')) {
+  if (!filWalletAddress || filWalletAddress.startsWith('f1') || filWalletAddress.startsWith('t1')) {
     // As a temporary fix to allow us to build & test the fraud detection pipeline,
     // we assign measurements from f1/t1 addresses to the same 0x participant.
     return '0xf100Ac342b7DE48e5c89f7029624eE6c3Cde68aC'

--- a/test/preprocess.js
+++ b/test/preprocess.js
@@ -42,7 +42,7 @@ describe('preprocess', () => {
     const cid = 'bafybeif2'
     const roundIndex = 0
     const measurements = [{
-      wallet_address: 't1foobar'
+      participant_address: 't1foobar'
     }]
     const web3Storage = {
       async get () {
@@ -59,8 +59,12 @@ describe('preprocess', () => {
     }
     const logger = { log () { }, error () { } }
     await preprocess({ rounds, cid, roundIndex, web3Storage, logger })
+    // We allow invalid participant address for now.
+    // We should update this test when we remove this temporary workaround.
     assert.deepStrictEqual(rounds, {
-      0: []
+      0: [{
+        participantAddress: '0xf100Ac342b7DE48e5c89f7029624eE6c3Cde68aC'
+      }]
     })
   })
 


### PR DESCRIPTION
Before this change, we would reject measurements with no participant
address with an ugly error:

```
Invalid measurement: Cannot read properties of undefined (reading 'startsWith') {
```

In this commit, I changed the address parser to map measurements with
missing participant address to the same hard-coded `0xf100` participant
as we map `f1`/`t1` participants.

This is a follow-up for #10
