### PR TITLE
test: remove delay after all tests are done

### DIFF
--- a/lib/telemetry.js
+++ b/lib/telemetry.js
@@ -20,3 +20,5 @@ export const record = (name, fn) => {
   fn(point)
   writeClient.writePoint(point)
 }
+
+export const close = () => writeClient.close()

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -1,8 +1,11 @@
 import { evaluate } from '../lib/evaluate.js'
 import assert from 'node:assert'
 import { ethers } from 'ethers'
+import * as telemetry from '../lib/telemetry.js'
 
 const { BigNumber } = ethers
+
+after(telemetry.close)
 
 describe('evaluate', () => {
   it('evaluates measurements', async () => {

--- a/test/preprocess.js
+++ b/test/preprocess.js
@@ -1,5 +1,8 @@
 import { parseParticipantAddress, preprocess } from '../lib/preprocess.js'
 import assert from 'node:assert'
+import * as telemetry from '../lib/telemetry.js'
+
+after(telemetry.close)
 
 describe('preprocess', () => {
   it('fetches measurements', async () => {


### PR DESCRIPTION
Before my change, there was a delay of approx. two seconds after all tests complete but before the Mocha process exits. This delay was caused by the recently added InfluxDB client (commit 09aaffcfe).

This commit modifies the test suite to explicitly close the InfluxDB client after all tests are finished.
