### PR TITLE
fix: don't record telemetry from tests

### DIFF
--- a/bin/spark-evaluate.js
+++ b/bin/spark-evaluate.js
@@ -5,6 +5,7 @@ import { ethers } from 'ethers'
 import { fileURLToPath } from 'node:url'
 import { newDelegatedEthAddress } from '@glif/filecoin-address'
 import { Web3Storage } from 'web3.storage'
+import { record } from '../lib/telemetry.js'
 import fs from 'node:fs/promises'
 
 const {
@@ -49,5 +50,6 @@ startEvaluate({
   ieContract,
   ieContractWithSigner,
   web3Storage,
+  record,
   logger: console
 })

--- a/bin/spark-evaluate.js
+++ b/bin/spark-evaluate.js
@@ -5,7 +5,7 @@ import { ethers } from 'ethers'
 import { fileURLToPath } from 'node:url'
 import { newDelegatedEthAddress } from '@glif/filecoin-address'
 import { Web3Storage } from 'web3.storage'
-import { record } from '../lib/telemetry.js'
+import { recordTelemetry } from '../lib/telemetry.js'
 import fs from 'node:fs/promises'
 
 const {
@@ -50,6 +50,6 @@ startEvaluate({
   ieContract,
   ieContractWithSigner,
   web3Storage,
-  record,
+  recordTelemetry,
   logger: console
 })

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ export const startEvaluate = ({
   ieContract,
   ieContractWithSigner,
   web3Storage,
-  record,
+  recordTelemetry,
   logger
 }) => {
   const rounds = {}
@@ -27,7 +27,7 @@ export const startEvaluate = ({
       cid,
       roundIndex,
       web3Storage,
-      record,
+      recordTelemetry,
       logger
     }).catch(err => {
       console.error(err)
@@ -52,7 +52,7 @@ export const startEvaluate = ({
       rounds,
       roundIndex: roundIndex - 1,
       ieContractWithSigner,
-      record,
+      recordTelemetry,
       logger
     }).catch(err => {
       console.error(err)

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ export const startEvaluate = ({
   ieContract,
   ieContractWithSigner,
   web3Storage,
+  record,
   logger
 }) => {
   const rounds = {}
@@ -25,6 +26,7 @@ export const startEvaluate = ({
       cid,
       roundIndex,
       web3Storage,
+      record,
       logger
     }).catch(console.error)
   })
@@ -41,6 +43,7 @@ export const startEvaluate = ({
       rounds,
       roundIndex: roundIndex - 1,
       ieContractWithSigner,
+      record,
       logger
     }).catch(console.error)
   })

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -2,7 +2,7 @@ export const evaluate = async ({
   rounds,
   roundIndex,
   ieContractWithSigner,
-  record,
+  recordTelemetry,
   logger
 }) => {
   // Get measurements
@@ -40,7 +40,7 @@ export const evaluate = async ({
   // Clean up
   delete rounds[roundIndex]
 
-  record('evaluate', point => {
+  recordTelemetry('evaluate', point => {
     point.intField('round_index', roundIndex)
     point.intField('total_participants', Object.keys(participants).length)
     point.intField('total_measurements', measurements.length)

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -1,9 +1,8 @@
-import { record } from './telemetry.js'
-
 export const evaluate = async ({
   rounds,
   roundIndex,
   ieContractWithSigner,
+  record,
   logger
 }) => {
   // Get measurements

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -7,7 +7,7 @@ export const preprocess = async ({
   cid,
   roundIndex,
   web3Storage,
-  record,
+  recordTelemetry,
   logger
 }) => {
   const start = new Date()
@@ -43,7 +43,7 @@ export const preprocess = async ({
   }
   rounds[roundIndex].push(...validMeasurements)
 
-  record('preprocess', point => {
+  recordTelemetry('preprocess', point => {
     point.intField('round_index', roundIndex)
     point.intField('total_measurements', measurements.length)
     point.intField('valid_measurements', validMeasurements.length)

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -1,13 +1,13 @@
 import assert from 'node:assert'
 import { ethers } from 'ethers'
 import { ethAddressFromDelegated } from '@glif/filecoin-address'
-import { record } from './telemetry.js'
 
 export const preprocess = async ({
   rounds,
   cid,
   roundIndex,
   web3Storage,
+  record,
   logger
 }) => {
   const start = new Date()

--- a/lib/telemetry.js
+++ b/lib/telemetry.js
@@ -15,7 +15,7 @@ setInterval(() => {
   writeClient.flush().catch(console.error)
 }, 10_000).unref()
 
-export const record = (name, fn) => {
+export const recordTelemetry = (name, fn) => {
   const point = new Point(name)
   fn(point)
   writeClient.writePoint(point)

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -1,11 +1,10 @@
 import { evaluate } from '../lib/evaluate.js'
 import assert from 'node:assert'
 import { ethers } from 'ethers'
-import * as telemetry from '../lib/telemetry.js'
 
 const { BigNumber } = ethers
 
-after(telemetry.close)
+const record = (measurementName, fn) => { /* no-op */ }
 
 describe('evaluate', () => {
   it('evaluates measurements', async () => {
@@ -25,6 +24,7 @@ describe('evaluate', () => {
       rounds,
       roundIndex: 0,
       ieContractWithSigner,
+      record,
       logger
     })
     assert.deepStrictEqual(rounds, {})
@@ -52,6 +52,7 @@ describe('evaluate', () => {
       rounds,
       roundIndex: 0,
       ieContractWithSigner,
+      record,
       logger
     })
     assert.strictEqual(setScoresCalls.length, 1)
@@ -74,6 +75,7 @@ describe('evaluate', () => {
       rounds,
       roundIndex: 0,
       ieContractWithSigner,
+      record,
       logger
     })
     assert.strictEqual(setScoresCalls.length, 1)
@@ -100,6 +102,7 @@ describe('evaluate', () => {
       rounds,
       roundIndex: 0,
       ieContractWithSigner,
+      record,
       logger
     })
     assert.strictEqual(setScoresCalls.length, 1)

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -4,7 +4,7 @@ import { ethers } from 'ethers'
 
 const { BigNumber } = ethers
 
-const record = (measurementName, fn) => { /* no-op */ }
+const recordTelemetry = (measurementName, fn) => { /* no-op */ }
 
 describe('evaluate', () => {
   it('evaluates measurements', async () => {
@@ -24,7 +24,7 @@ describe('evaluate', () => {
       rounds,
       roundIndex: 0,
       ieContractWithSigner,
-      record,
+      recordTelemetry,
       logger
     })
     assert.deepStrictEqual(rounds, {})
@@ -52,7 +52,7 @@ describe('evaluate', () => {
       rounds,
       roundIndex: 0,
       ieContractWithSigner,
-      record,
+      recordTelemetry,
       logger
     })
     assert.strictEqual(setScoresCalls.length, 1)
@@ -75,7 +75,7 @@ describe('evaluate', () => {
       rounds,
       roundIndex: 0,
       ieContractWithSigner,
-      record,
+      recordTelemetry,
       logger
     })
     assert.strictEqual(setScoresCalls.length, 1)
@@ -102,7 +102,7 @@ describe('evaluate', () => {
       rounds,
       roundIndex: 0,
       ieContractWithSigner,
-      record,
+      recordTelemetry,
       logger
     })
     assert.strictEqual(setScoresCalls.length, 1)

--- a/test/preprocess.js
+++ b/test/preprocess.js
@@ -1,7 +1,7 @@
 import { parseParticipantAddress, preprocess } from '../lib/preprocess.js'
 import assert from 'node:assert'
 
-const record = (measurementName, fn) => { /* no-op */ }
+const recordTelemetry = (measurementName, fn) => { /* no-op */ }
 
 describe('preprocess', () => {
   it('fetches measurements', async () => {
@@ -27,7 +27,7 @@ describe('preprocess', () => {
       }
     }
     const logger = { log () {}, error: console.error }
-    await preprocess({ rounds, cid, roundIndex, web3Storage, record, logger })
+    await preprocess({ rounds, cid, roundIndex, web3Storage, recordTelemetry, logger })
 
     assert.deepStrictEqual(rounds, {
       0: [{
@@ -57,7 +57,7 @@ describe('preprocess', () => {
       }
     }
     const logger = { log () { }, error () { } }
-    await preprocess({ rounds, cid, roundIndex, web3Storage, record, logger })
+    await preprocess({ rounds, cid, roundIndex, web3Storage, recordTelemetry, logger })
     // We allow invalid participant address for now.
     // We should update this test when we remove this temporary workaround.
     assert.deepStrictEqual(rounds, {

--- a/test/preprocess.js
+++ b/test/preprocess.js
@@ -1,8 +1,7 @@
 import { parseParticipantAddress, preprocess } from '../lib/preprocess.js'
 import assert from 'node:assert'
-import * as telemetry from '../lib/telemetry.js'
 
-after(telemetry.close)
+const record = (measurementName, fn) => { /* no-op */ }
 
 describe('preprocess', () => {
   it('fetches measurements', async () => {
@@ -28,7 +27,7 @@ describe('preprocess', () => {
       }
     }
     const logger = { log () {}, error: console.error }
-    await preprocess({ rounds, cid, roundIndex, web3Storage, logger })
+    await preprocess({ rounds, cid, roundIndex, web3Storage, record, logger })
 
     assert.deepStrictEqual(rounds, {
       0: [{
@@ -58,7 +57,7 @@ describe('preprocess', () => {
       }
     }
     const logger = { log () { }, error () { } }
-    await preprocess({ rounds, cid, roundIndex, web3Storage, logger })
+    await preprocess({ rounds, cid, roundIndex, web3Storage, record, logger })
     // We allow invalid participant address for now.
     // We should update this test when we remove this temporary workaround.
     assert.deepStrictEqual(rounds, {


### PR DESCRIPTION
Modify the processing pipeline to accept the `record` function via dependency injection.

Rework the test suite to supply a dummy no-op `record` function so we don't corrupt telemetry data from production with telemetry submitted by tests.

Links to:
- https://github.com/filecoin-station/spark/issues/13
- https://github.com/filecoin-station/spark/issues/18