### PR TITLE
feat: improve logging

### DIFF
--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -28,21 +28,8 @@ export const evaluate = async ({
       BigInt(honestMeasurements.length)
   }
 
-  // Submit scores to IE
-  logger.log('setScores()')
-  const start = new Date()
-  const tx = await ieContractWithSigner.setScores(
-    roundIndex,
-    Object.keys(participants),
-    Object.values(participants)
-  )
-  const setScoresDuration = new Date() - start
-  logger.log(`Hash: ${tx.hash}`)
-
-  // Clean up
-  delete rounds[roundIndex]
-
   // Calculate aggregates per fraud detection outcome
+  // This is used for logging and telemetry
   const fraudAssessments = {
     OK: 0,
     INVALID_TASK: 0
@@ -50,6 +37,35 @@ export const evaluate = async ({
   for (const m of measurements) {
     fraudAssessments[m.fraudAssessment] = (fraudAssessments[m.fraudAssessment] ?? 0) + 1
   }
+  logger.log(
+    'EVALUTE ROUND %s: Evaluated %s measurements, found %s honest entries.\n%o',
+    roundIndex,
+    measurements.length,
+    honestMeasurements.length,
+    fraudAssessments
+  )
+
+  // Submit scores to IE
+
+  const totalScore = Object.values(participants).reduce((sum, val) => sum + val, 0n)
+  logger.log(
+    'EVALUTE ROUND %s: Invoking IE.setScores(); number of participants: %s, total score: %s',
+    roundIndex,
+    Object.keys(participants).length,
+    totalScore === 1000000000000000n ? '100%' : totalScore
+  )
+
+  const start = new Date()
+  const tx = await ieContractWithSigner.setScores(
+    roundIndex,
+    Object.keys(participants),
+    Object.values(participants)
+  )
+  const setScoresDuration = new Date() - start
+  logger.log('EVALUTE ROUND %s: IE.setScores() TX hash: %s', roundIndex, tx.hash)
+
+  // Clean up
+  delete rounds[roundIndex]
 
   recordTelemetry('evaluate', point => {
     point.intField('round_index', roundIndex)

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -36,7 +36,12 @@ export const preprocess = async ({
         return false
       }
     })
-  logger.log(`Fetched ${validMeasurements.length} valid measurements`)
+  logger.log(
+    'PREPROCESS ROUND %s: Added measurements from CID %s\n%o',
+    roundIndex,
+    cid,
+    { total: measurements.length, valid: validMeasurements.length }
+  )
 
   if (!rounds[roundIndex]) {
     rounds[roundIndex] = []


### PR DESCRIPTION
Example of preprocessing logs:

```
PREPROCESS ROUND 0: Added measurements from CID bafybeif2
{ total: 1, valid: 1 }
```

Example of evaluation logs:

```
EVALUTE ROUND 0: Evaluated 10 measurements, found 10 honest entries.
{ OK: 10, INVALID_TASK: 0 }
EVALUTE ROUND 0: Invoking IE.setScores(); number of participants: 1, total score: 100%
EVALUTE ROUND 0: IE.setScores() TX hash: 0x234
```
