### PR TITLE
feat: add a bin script to run evaluation locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ $ WALLET_SEED=$(cat secrets/mnemonic) WEB3_STORAGE_API_TOKEN=$(cat secrets/web3s
 $ npm test
 ```
 
+## Troubleshooting
+
+You can perform a dry-run evaluation of a given SPARK round using the script `bin/dry-run.js`.
+
+At the moment, the script requires CID(s) of measurements to load. (In the future, we may discover
+those CIDs from on-chain events.)
+
+Example: evaluate round `273` with measurements from CID `bafybeie5rekb2jox77ow64wjjd2bjdsp6d3yeivhzzd234hnbpscfjarv4z`.
+
+```shell
+❯ node bin/dry-run.js 273 bafybeie5rekb2jox77ow64wjjd2bjdsp6d3yeivhzzd234hnbpscfjarv4
+```
+
 ## Deployment
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ $ npm test
 
 ## Troubleshooting
 
-You can perform a dry-run evaluation of a given SPARK round using the script `bin/dry-run.js`.
+You can perform a dry-run evaluation of a given Meridan round using the script `bin/dry-run.js`.
 
 At the moment, the script requires CID(s) of measurements to load. (In the future, we may discover
 those CIDs from on-chain events.)
 
-Example: evaluate round `273` with measurements from CID `bafybeie5rekb2jox77ow64wjjd2bjdsp6d3yeivhzzd234hnbpscfjarv4z`.
+Example: evaluate round `273` of Meridian version `0x3113b83ccec38a18df936f31297de490485d7b2e` with measurements from CID `bafybeie5rekb2jox77ow64wjjd2bjdsp6d3yeivhzzd234hnbpscfjarv4z`.
 
 ```shell
-❯ node bin/dry-run.js 273 bafybeie5rekb2jox77ow64wjjd2bjdsp6d3yeivhzzd234hnbpscfjarv4
+❯ node bin/dry-run.js 0x3113b83ccec38a18df936f31297de490485d7b2e 273 bafybeie5rekb2jox77ow64wjjd2bjdsp6d3yeivhzzd234hnbpscfjarv4
 ```
 
 ## Deployment

--- a/bin/dry-run.js
+++ b/bin/dry-run.js
@@ -1,12 +1,18 @@
 import { evaluate } from '../lib/evaluate.js'
 import { fetchRoundDetails } from '../lib/spark-api.js'
 
-const [nodePath, selfPath, roundIndex, ...measurementCids] = process.argv
+const [nodePath, selfPath, contractAddress, roundIndex, ...measurementCids] = process.argv
 
 const USAGE = `
 Usage:
-  ${nodePath} ${selfPath} <round-index> <measurements-cid-1> [cid2 [cid3...]]
+  ${nodePath} ${selfPath} <contract-address> <round-index> <measurements-cid-1> [cid2 [cid3...]]
 `
+
+if (!contractAddress) {
+  console.error('Missing required argument: contractAddress')
+  console.log(USAGE)
+  process.exit(1)
+}
 
 if (!roundIndex) {
   console.error('Missing required argument: roundIndex')
@@ -37,6 +43,7 @@ console.log('Evaluating round %s', roundIndex)
 console.log('Fetched %s measurements', measurements.length)
 
 const ieContractWithSigner = {
+  address: contractAddress,
   async setScores (_roundIndex, participantAddresses, scores) {
     console.log('==EVALUATION RESULTS==')
     console.log('participants:', participantAddresses)

--- a/bin/dry-run.js
+++ b/bin/dry-run.js
@@ -1,0 +1,57 @@
+import { evaluate } from '../lib/evaluate.js'
+import { fetchRoundDetails } from '../lib/spark-api.js'
+
+const [nodePath, selfPath, roundIndex, ...measurementCids] = process.argv
+
+const USAGE = `
+Usage:
+  ${nodePath} ${selfPath} <round-index> <measurements-cid-1> [cid2 [cid3...]]
+`
+
+if (!roundIndex) {
+  console.error('Missing required argument: roundIndex')
+  console.log(USAGE)
+  process.exit(1)
+}
+
+// TODO: fetch measurement CIDs from on-chain events
+if (!measurementCids.length) {
+  console.error('Missing required argument: measurements CID (at least one is required)')
+  console.log(USAGE)
+  process.exit(1)
+}
+
+// TODO: fetch measurements via preprocess
+const measurements = []
+for (const cid of measurementCids) {
+  const res = await fetch(`https://${cid}.ipfs.w3s.link/measurements.json`)
+  if (!res.ok) {
+    console.log('Cannot fetch %s: %s %s', cid, res.status, await res.text())
+    process.exit(2)
+  }
+  const data = await res.json()
+  measurements.push(...data)
+}
+
+console.log('Evaluating round %s', roundIndex)
+console.log('Fetched %s measurements', measurements.length)
+
+const ieContractWithSigner = {
+  async setScores (_roundIndex, participantAddresses, scores) {
+    console.log('==EVALUATION RESULTS==')
+    console.log('participants:', participantAddresses)
+    console.log('scores:', scores)
+    console.log('==END OF RESULTS==')
+    return { hash: '0x234' }
+  }
+}
+const recordTelemetry = (measurementName, fn) => { /* no-op */ }
+
+await evaluate({
+  roundIndex,
+  rounds: { [roundIndex]: measurements },
+  fetchRoundDetails,
+  ieContractWithSigner,
+  logger: console,
+  recordTelemetry
+})


### PR DESCRIPTION
Example:

```
❯ node bin/dry-run.js 0x3113b83ccec38a18df936f31297de490485d7b2e 273 bafybeie5rekb2jox77ow64wjjd2bjdsp6d3yeivhzzd234hnbpscfjarv4
Evaluating round 273 of contract 0x3113b83ccec38a18df936f31297de490485d7b2e
==PREPROCESS==
PREPROCESS ROUND 273: Added measurements from CID bafybeie5rekb2jox77ow64wjjd2bjdsp6d3yeivhzzd234hnbpscfjarv4
{ total: 16, valid: 16 }
Fetched 16 measurements
==EVALUATE==
EVALUTE ROUND 273: Evaluated 16 measurements, found 15 honest entries.
{ OK: 15, INVALID_TASK: 1 }
EVALUTE ROUND 273: Invoking IE.setScores(); number of participants: 2, total score: 999999999999999n
==EVALUATION RESULTS==
participants: [
  '0xf100Ac342b7DE48e5c89f7029624eE6c3Cde68aC',
  '0x000000000000000000000000000000000000dEaD'
]
scores: [ 933333333333333n, 66666666666666n ]
==END OF RESULTS==
EVALUTE ROUND 273: IE.setScores() TX hash: 0x234
```