### PR TITLE
fix: fetch SPARK round details by IE round

### DIFF
--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -15,7 +15,12 @@ export const evaluate = async ({
   const measurements = rounds[roundIndex] || []
 
   // Detect fraud
-  await runFraudDetection(roundIndex, measurements, { fetchRoundDetails, recordTelemetry })
+
+  const sparkRoundDetails = await fetchRoundDetails(ieContractWithSigner.address, roundIndex, recordTelemetry)
+  // Omit the roundDetails object from the format string to get nicer formatting
+  debug('ROUND DETAILS for round=%s', roundIndex, sparkRoundDetails)
+
+  await runFraudDetection(roundIndex, measurements, sparkRoundDetails)
   const honestMeasurements = measurements.filter(m => m.fraudAssessment === 'OK')
 
   // Calculate reward shares
@@ -84,13 +89,9 @@ export const evaluate = async ({
   })
 }
 
-export const runFraudDetection = async (roundIndex, measurements, { fetchRoundDetails, recordTelemetry }) => {
-  const roundDetails = await fetchRoundDetails(roundIndex, recordTelemetry)
-  // Omit the roundDetails object from the format string to get nicer formatting
-  debug('ROUND DETAILS for round=%s', roundIndex, roundDetails)
-
+export const runFraudDetection = async (roundIndex, measurements, sparkRoundDetails) => {
   for (const m of measurements) {
-    const isValidTask = roundDetails.retrievalTasks.some(t =>
+    const isValidTask = sparkRoundDetails.retrievalTasks.some(t =>
       t.cid === m.cid && t.providerAddress === m.provider_address & t.protocol === m.protocol
     )
     if (!isValidTask) {

--- a/lib/spark-api.js
+++ b/lib/spark-api.js
@@ -1,14 +1,18 @@
 import { SPARK_API } from './config.js'
 
-export const fetchRoundDetails = async (/** @type {BigInt} */ roundIndex, recordTelemetry) => {
+export const fetchRoundDetails = async (
+  /** @type {string} */ contractAddress,
+  /** @type {BigInt} */ roundIndex,
+  recordTelemetry
+) => {
   const start = new Date()
   let status = 0
 
   try {
-    const res = await fetch(`${SPARK_API}/rounds/${roundIndex}`)
+    const res = await fetch(`${SPARK_API}/rounds/meridian/${contractAddress}/${roundIndex}`)
     status = res.status
     if (!res.ok) {
-      const msg = `Cannot fetch tasks for round ${roundIndex}: ${status}\n${await res.text()}`
+      const msg = `Cannot fetch tasks for round ${contractAddress}/${roundIndex}: ${status}\n${await res.text()}`
       throw new Error(msg)
     }
     /** @type {import('./typings.d.ts').RoundDetails} */
@@ -16,6 +20,7 @@ export const fetchRoundDetails = async (/** @type {BigInt} */ roundIndex, record
     return details
   } finally {
     recordTelemetry('fetch_tasks_for_round', point => {
+      point.intField('contract_address', contractAddress)
       point.intField('round_index', roundIndex)
       point.intField('fetch_duration_ms', new Date() - start)
       point.intField('status', status)

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -153,7 +153,7 @@ describe('evaluate', () => {
 describe('fraud detection', () => {
   it('checks if measurements are for a valid task', async () => {
     const sparkRoundDetails = {
-      roundId: 1234, // doesn't matter
+      roundId: 1234, // doesn't matte
       retrievalTasks: [
         {
           cid: 'QmUuEoBdjC8D1PfWZCc7JCSK8nj7TV6HbXWDHYHzZHCVGS',

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -31,7 +31,7 @@ describe('evaluate', () => {
     for (let i = 0; i < 10; i++) {
       rounds[0].push(VALID_MEASUREMENT)
     }
-    const fetchRoundDetails = (_roundIndex) => ({ retrievalTasks: [VALID_TASK] })
+    const fetchRoundDetails = () => ({ retrievalTasks: [VALID_TASK] })
     const setScoresCalls = []
     const ieContractWithSigner = {
       async setScores (roundIndex, participantAddresses, scores) {
@@ -68,7 +68,7 @@ describe('evaluate', () => {
       }
     }
     const logger = { log: debug, error: debug }
-    const fetchRoundDetails = (_roundIndex) => ({ retrievalTasks: [VALID_TASK] })
+    const fetchRoundDetails = () => ({ retrievalTasks: [VALID_TASK] })
     await evaluate({
       rounds,
       roundIndex: 0,
@@ -92,7 +92,7 @@ describe('evaluate', () => {
       }
     }
     const logger = { log: debug, error: debug }
-    const fetchRoundDetails = (_roundIndex) => ({ retrievalTasks: [VALID_TASK] })
+    const fetchRoundDetails = () => ({ retrievalTasks: [VALID_TASK] })
     await evaluate({
       rounds,
       roundIndex: 0,
@@ -127,7 +127,7 @@ describe('evaluate', () => {
       }
     }
     const logger = { log: debug, error: debug }
-    const fetchRoundDetails = (_roundIndex) => ({ retrievalTasks: [VALID_TASK] })
+    const fetchRoundDetails = () => ({ retrievalTasks: [VALID_TASK] })
     await evaluate({
       rounds,
       roundIndex: 0,
@@ -152,8 +152,8 @@ describe('evaluate', () => {
 
 describe('fraud detection', () => {
   it('checks if measurements are for a valid task', async () => {
-    const fetchRoundDetails = (roundIndex) => ({
-      roundId: roundIndex,
+    const sparkRoundDetails = {
+      roundId: 1234, // doesn't matter
       retrievalTasks: [
         {
           cid: 'QmUuEoBdjC8D1PfWZCc7JCSK8nj7TV6HbXWDHYHzZHCVGS',
@@ -161,7 +161,7 @@ describe('fraud detection', () => {
           protocol: 'bitswap'
         }
       ]
-    })
+    }
 
     const measurements = [
       {
@@ -180,7 +180,7 @@ describe('fraud detection', () => {
       }
     ]
 
-    await runFraudDetection(1, measurements, { fetchRoundDetails, recordTelemetry })
+    await runFraudDetection(1, measurements, sparkRoundDetails)
     assert.deepStrictEqual(
       measurements.map(m => m.fraudAssessment),
       ['OK', 'INVALID_TASK']

--- a/test/spark-api.js
+++ b/test/spark-api.js
@@ -12,18 +12,18 @@ describe('spark-api client', () => {
     )
 
     assert.deepStrictEqual(details, {
-      roundId: '520' // BigInt serialized as String
+      roundId: '995' // BigInt serialized as String
     })
 
     assert.strictEqual(retrievalTasks.length, 30)
     assert.deepStrictEqual(retrievalTasks.slice(0, 2), [
       {
-        cid: 'bafkreibngqhl3gaa7daob4i2vccziay2jjlp435cf66vhono7nrvww53ty',
-        protocol: 'graphsync',
-        providerAddress: '/ip4/89.20.96.58/tcp/24001/p2p/12D3KooWDMJSprsuxhjJVnuQQcyibc5GxanUUxpDzHU74rhknqkU'
+        cid: 'QmUen1QdStwcqYaRJKW59GfEk1y8TyqyrvisZ5Mm2ZwMhU',
+        protocol: 'bitswap',
+        providerAddress: '/dns4/elastic.dag.house/tcp/443/wss/p2p/QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC'
       },
       {
-        cid: 'bafybeib4bxcp5y6wjz24ckzhxv2nypibvqcldim37pmy2ayrny5rrqboou',
+        cid: 'bafybeidijvhvuvizg2ofeqos7l2kd4uanbawzx6qazyko5kbvth6dlhn5e',
         protocol: 'bitswap',
         providerAddress: '/dns4/elastic.dag.house/tcp/443/wss/p2p/QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC'
       }

--- a/test/spark-api.js
+++ b/test/spark-api.js
@@ -5,7 +5,11 @@ const recordTelemetry = (measurementName, fn) => { /* no-op */ }
 
 describe('spark-api client', () => {
   it('fetches round details', async () => {
-    const { retrievalTasks, ...details } = await fetchRoundDetails(520, recordTelemetry)
+    const { retrievalTasks, ...details } = await fetchRoundDetails(
+      '0x381b50e8062757c404dec2bfae4da1b495341af9',
+      10,
+      recordTelemetry
+    )
 
     assert.deepStrictEqual(details, {
       roundId: '520' // BigInt serialized as String


### PR DESCRIPTION
Rework `fetchRoundDetails` to invoke the API endpoint that returns SPARK round details for the provided IE contract address & round index.

Links:
- https://github.com/filecoin-station/spark/issues/13
- https://github.com/filecoin-station/spark-api/pull/103