### PR TITLE
refactor: simplify injection of fetchMeasurements

### DIFF
--- a/bin/spark-evaluate.js
+++ b/bin/spark-evaluate.js
@@ -8,6 +8,7 @@ import { newDelegatedEthAddress } from '@glif/filecoin-address'
 import { Web3Storage } from 'web3.storage'
 import { recordTelemetry } from '../lib/telemetry.js'
 import fs from 'node:fs/promises'
+import { fetchMeasurementsViaClient } from '../lib/preprocess.js'
 
 const {
   SENTRY_ENVIRONMMENT = 'development',
@@ -46,11 +47,12 @@ const ieContract = new ethers.Contract(
 )
 const ieContractWithSigner = ieContract.connect(signer)
 const web3Storage = new Web3Storage({ token: WEB3_STORAGE_API_TOKEN })
+const fetchMeasurements = (cid) => fetchMeasurementsViaClient(web3Storage, cid)
 
 startEvaluate({
   ieContract,
   ieContractWithSigner,
-  web3Storage,
+  fetchMeasurements,
   fetchRoundDetails,
   recordTelemetry,
   logger: console

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import { evaluate } from './lib/evaluate.js'
 export const startEvaluate = ({
   ieContract,
   ieContractWithSigner,
-  web3Storage,
+  fetchMeasurements,
   fetchRoundDetails,
   recordTelemetry,
   logger
@@ -27,7 +27,7 @@ export const startEvaluate = ({
       rounds,
       cid,
       roundIndex,
-      web3Storage,
+      fetchMeasurements,
       recordTelemetry,
       logger
     }).catch(err => {

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -6,12 +6,12 @@ export const preprocess = async ({
   rounds,
   cid,
   roundIndex,
-  web3Storage,
+  fetchMeasurements,
   recordTelemetry,
   logger
 }) => {
   const start = new Date()
-  const measurements = await fetchMeasurements(web3Storage, cid)
+  const measurements = await fetchMeasurements(cid)
   const fetchDuration = new Date() - start
   const validMeasurements = measurements
     // eslint-disable-next-line camelcase
@@ -56,10 +56,20 @@ export const preprocess = async ({
   })
 }
 
-const fetchMeasurements = async (web3Storage, cid) => {
+export const fetchMeasurementsViaClient = async (web3Storage, cid) => {
   const res = await web3Storage.get(cid)
   const files = await res.files()
   const measurements = JSON.parse(await files[0].text())
+  return measurements
+}
+
+export const fetchMeasurementsViaGateway = async (cid) => {
+  const res = await fetch(`https://${encodeURIComponent(cid)}.ipfs.w3s.link/measurements.json`)
+  if (!res.ok) {
+    const msg = `Cannot fetch measurements ${cid}: ${res.status}\n${await res.text()}`
+    throw new Error(msg)
+  }
+  const measurements = await res.json()
   return measurements
 }
 

--- a/test/preprocess.js
+++ b/test/preprocess.js
@@ -18,22 +18,12 @@ describe('preprocess', () => {
       participant_address: 'f410ftgmzttyqi3ti4nxbvixa4byql3o5d4eo3jtc43i'
     }]
     const getCalls = []
-    const web3Storage = {
-      async get (_cid) {
-        getCalls.push(_cid)
-        return {
-          async files () {
-            return [{
-              async text () {
-                return JSON.stringify(measurements)
-              }
-            }]
-          }
-        }
-      }
+    const fetchMeasurements = async (cid) => {
+      getCalls.push(cid)
+      return measurements
     }
     const logger = { log: debug, error: console.error }
-    await preprocess({ rounds, cid, roundIndex, web3Storage, recordTelemetry, logger })
+    await preprocess({ rounds, cid, roundIndex, fetchMeasurements, recordTelemetry, logger })
 
     assert.deepStrictEqual(rounds, {
       0: [{
@@ -49,21 +39,9 @@ describe('preprocess', () => {
     const measurements = [{
       participant_address: 't1foobar'
     }]
-    const web3Storage = {
-      async get () {
-        return {
-          async files () {
-            return [{
-              async text () {
-                return JSON.stringify(measurements)
-              }
-            }]
-          }
-        }
-      }
-    }
+    const fetchMeasurements = async (_cid) => measurements
     const logger = { log: debug, error: debug }
-    await preprocess({ rounds, cid, roundIndex, web3Storage, recordTelemetry, logger })
+    await preprocess({ rounds, cid, roundIndex, fetchMeasurements, recordTelemetry, logger })
     // We allow invalid participant address for now.
     // We should update this test when we remove this temporary workaround.
     assert.deepStrictEqual(rounds, {


### PR DESCRIPTION
Rework the preprocessor to expect a function with a simpler signature for retrieving measurements stored in the given CID.

This simplifies existing unit tests and enables future work like anonymous "dry-run" (see #31)
