### PR TITLE
fix: telemetry field type for contract address

### DIFF
--- a/lib/spark-api.js
+++ b/lib/spark-api.js
@@ -20,7 +20,7 @@ export const fetchRoundDetails = async (
     return details
   } finally {
     recordTelemetry('fetch_tasks_for_round', point => {
-      point.intField('contract_address', contractAddress)
+      point.stringField('contract_address', contractAddress)
       point.intField('round_index', roundIndex)
       point.intField('fetch_duration_ms', new Date() - start)
       point.intField('status', status)

--- a/lib/spark-api.js
+++ b/lib/spark-api.js
@@ -1,8 +1,13 @@
 import { SPARK_API } from './config.js'
 
+/**
+ * @param {string} contractAddress
+ * @param {BigInt} roundIndex
+ * @param {import('./typings').RecordTelemetryFn} recordTelemetry
+ */
 export const fetchRoundDetails = async (
-  /** @type {string} */ contractAddress,
-  /** @type {BigInt} */ roundIndex,
+  contractAddress,
+  roundIndex,
   recordTelemetry
 ) => {
   const start = new Date()

--- a/lib/typings.d.ts
+++ b/lib/typings.d.ts
@@ -1,3 +1,5 @@
+import { Point } from '@influxdata/influxdb-client'
+
 /**
  * Details of a retrieval task as returned by SPARK HTTP API.
  */
@@ -14,3 +16,8 @@ export interface RoundDetails {
   roundId: string; // BigInt serialized as String (JSON does not support BigInt)
   retrievalTasks: RetrievalTask[];
 }
+
+export type RecordTelemetryFn = (
+  name: string,
+  fn: (point: Point) => void
+) => void


### PR DESCRIPTION
Fix the following error by changing the field type from int to string:

```
Event: RoundStart { roundIndex: 327 }
Error: invalid integer value for field 'contract_address': '0x3113b83ccec38a18df936f31297de490485d7b2e'!
at ve.intField (file:///app/node_modules/@influxdata/influxdb-client/dist/index.mjs:4:2656)
at file:///app/lib/spark-api.js:23:13
at recordTelemetry (file:///app/lib/telemetry.js:20:3)
at fetchRoundDetails (file:///app/lib/spark-api.js:22:5)
at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
at async evaluate (file:///app/lib/evaluate.js:19:29)
```

Also add types for the function `recordTelemetry()` to make it easier to discover Point methods available for different data types.

Links:
- https://github.com/filecoin-station/spark/issues/13