### PR TITLE
feat: round scores to MAX_SCORE

### DIFF
--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -2,6 +2,8 @@ import createDebug from 'debug'
 
 const debug = createDebug('spark:evaluate')
 
+export const MAX_SCORE = 1_000_000_000_000_000n
+
 export const evaluate = async ({
   rounds,
   roundIndex,
@@ -25,6 +27,7 @@ export const evaluate = async ({
 
   // Calculate reward shares
   const participants = {}
+  let sum = 0n
   for (const measurement of honestMeasurements) {
     if (!participants[measurement.participantAddress]) {
       participants[measurement.participantAddress] = 0n
@@ -32,9 +35,18 @@ export const evaluate = async ({
     participants[measurement.participantAddress] += 1n
   }
   for (const [participantAddress, participantTotal] of Object.entries(participants)) {
-    participants[participantAddress] = participantTotal *
-      1_000_000_000_000_000n /
+    const score = participantTotal *
+      MAX_SCORE /
       BigInt(honestMeasurements.length)
+    participants[participantAddress] = score
+    sum += score
+  }
+
+  if (Object.keys(participants).length && sum < MAX_SCORE) {
+    const delta = MAX_SCORE - sum
+    const score = (participants['0x000000000000000000000000000000000000dEaD'] ?? 0n) + delta
+    participants['0x000000000000000000000000000000000000dEaD'] = score
+    logger.log('EVALUATE ROUND %s: added %s as rounding to MAX_SCORE', roundIndex, delta)
   }
 
   // Calculate aggregates per fraud detection outcome

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -1,4 +1,4 @@
-import { evaluate, runFraudDetection } from '../lib/evaluate.js'
+import { MAX_SCORE, evaluate, runFraudDetection } from '../lib/evaluate.js'
 import assert from 'node:assert'
 import { ethers } from 'ethers'
 import createDebug from 'debug'
@@ -147,6 +147,37 @@ describe('evaluate', () => {
       `Sum of scores not close enough. Got ${sum}`
     )
     assert.strictEqual(setScoresCalls[0].scores.length, 2)
+  })
+
+  it('adds a dummy entry to ensure scores add up exactly to MAX_SCORE', async () => {
+    const rounds = { 0: [] }
+    rounds[0].push({ ...VALID_MEASUREMENT, participantAddress: '0x123' })
+    rounds[0].push({ ...VALID_MEASUREMENT, participantAddress: '0x234' })
+    rounds[0].push({ ...VALID_MEASUREMENT, participantAddress: '0x456' })
+
+    const setScoresCalls = []
+    const ieContractWithSigner = {
+      async setScores (_, participantAddresses, scores) {
+        setScoresCalls.push({ participantAddresses, scores })
+        return { hash: '0x345' }
+      }
+    }
+    const logger = { log: debug, error: debug }
+    const fetchRoundDetails = () => ({ retrievalTasks: [VALID_TASK] })
+    await evaluate({
+      rounds,
+      roundIndex: 0,
+      ieContractWithSigner,
+      recordTelemetry,
+      fetchRoundDetails,
+      logger
+    })
+    assert.strictEqual(setScoresCalls.length, 1)
+    const { scores, participantAddresses } = setScoresCalls[0]
+    assert.strictEqual(scores.length, 4)
+    const sum = scores.reduce((prev, score) => (prev ?? 0) + score)
+    assert.strictEqual(sum, MAX_SCORE)
+    assert.strictEqual(participantAddresses.sort()[0], '0x000000000000000000000000000000000000dEaD')
   })
 })
 


### PR DESCRIPTION
Ensure all scores add up to `MAX_SCORE` by adding a new entry assigning the remainder to the special address `0x000[...]000000000000000dEaD`.

The smart contract recognises this address and does not pay any rewards to it.

Resolve #49
