### PR TITLE
feat: cache fetched measurements in dry-run tool

### DIFF
--- a/bin/dry-run.js
+++ b/bin/dry-run.js
@@ -1,6 +1,9 @@
 import { evaluate } from '../lib/evaluate.js'
 import { preprocess, fetchMeasurementsViaGateway } from '../lib/preprocess.js'
 import { fetchRoundDetails } from '../lib/spark-api.js'
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 const [nodePath, selfPath, contractAddress, roundIndex, ...measurementCids] = process.argv
 
@@ -28,7 +31,22 @@ if (!measurementCids.length) {
   process.exit(1)
 }
 
+const cacheDir = fileURLToPath(new URL('../.cache', import.meta.url))
+await mkdir(cacheDir, { recursive: true })
+
 const recordTelemetry = (measurementName, fn) => { /* no-op */ }
+const fetchMeasurements = async (cid) => {
+  const pathOfCachedResponse = path.join(cacheDir, cid + '.json')
+  try {
+    return JSON.parse(await readFile(pathOfCachedResponse, 'utf-8'))
+  } catch (err) {
+    if (err.code !== 'ENOENT') console.warn('Cannot read cached measurements:', err)
+  }
+
+  const measurements = await fetchMeasurementsViaGateway(cid)
+  await writeFile(pathOfCachedResponse, JSON.stringify(measurements))
+  return measurements
+}
 
 console.log('Evaluating round %s of contract %s', roundIndex, contractAddress)
 
@@ -40,7 +58,7 @@ for (const cid of measurementCids) {
     roundIndex,
     rounds,
     cid,
-    fetchMeasurements: fetchMeasurementsViaGateway,
+    fetchMeasurements,
     recordTelemetry,
     logger: console
   })


### PR DESCRIPTION
I am investigating why we get `undefined` fraud assessments in our evaluations. To speed up the dry-run evaluations, I want to cache measurements to speed up sub-sequent dry-run evaluations of the same round.