### PR TITLE
feat: report unique tasks in honest measurements

### DIFF
--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -110,6 +110,7 @@ export const evaluate = async ({
     point.intField('total_participants', Object.keys(participants).length)
     point.intField('total_measurements', measurements.length)
     point.intField('honest_measurements', honestMeasurements.length)
+    point.intField('unique_tasks', countUniqueTasks(honestMeasurements))
     point.intField('set_scores_duration_ms', setScoresDuration)
 
     for (const [type, count] of Object.entries(fraudAssessments)) {
@@ -276,4 +277,21 @@ const calculateInetGroupSuccessRates = (taskGroups) => {
   result.mean = sum / participantStats.size
 
   return result
+}
+
+/**
+ * @param {import('./typings').Measurement[]} measurements
+ * @returns {number}
+ */
+const countUniqueTasks = (measurements) => {
+  const getTaskId = (/** @type {import('./typings').Measurement} */m) =>
+    `${m.cid}::${m.protocol}::${m.provider_address}`
+
+  const uniqueTasks = new Set()
+  for (const m of measurements) {
+    const id = getTaskId(m)
+    uniqueTasks.add(id)
+  }
+
+  return uniqueTasks.size
 }

--- a/lib/telemetry.js
+++ b/lib/telemetry.js
@@ -23,3 +23,7 @@ export const recordTelemetry = (name, fn) => {
 }
 
 export const close = () => writeClient.close()
+
+export {
+  Point
+}


### PR DESCRIPTION
Now that our CID dataset has ~300k items, there is little value in observing the count of samples. Instead, I would like to see how many unique retrieval tasks we are able to test each round and over time.

In this change, I am adding a new field to the existing telemetry point "evaluate" with the count of unique tasks found in the honest measurements.

While we could get this data by querying the `measurements` table, such query is extremely expensive and cannot filter out measurements not considered as honest.

Links:
- https://github.com/filecoin-station/roadmap/issues/43