### PR TITLE
test: update spark-api to use a more recent round

### DIFF
--- a/lib/spark-api.js
+++ b/lib/spark-api.js
@@ -12,6 +12,7 @@ export const fetchRoundDetails = async (
 ) => {
   const start = new Date()
   let status = 0
+  let taskCount
 
   try {
     const res = await fetch(`${SPARK_API}/rounds/meridian/${contractAddress}/${roundIndex}`)
@@ -22,6 +23,7 @@ export const fetchRoundDetails = async (
     }
     /** @type {import('./typings.d.ts').RoundDetails} */
     const details = res.json()
+    taskCount = details.retrievalTasks?.length
     return details
   } finally {
     recordTelemetry('fetch_tasks_for_round', point => {
@@ -29,6 +31,7 @@ export const fetchRoundDetails = async (
       point.intField('round_index', roundIndex)
       point.intField('fetch_duration_ms', new Date() - start)
       point.intField('status', status)
+      point.intField('task_count', taskCount ?? -1)
     })
   }
 }

--- a/test/spark-api.js
+++ b/test/spark-api.js
@@ -6,26 +6,26 @@ const recordTelemetry = (measurementName, fn) => { /* no-op */ }
 describe('spark-api client', () => {
   it('fetches round details', async () => {
     const { retrievalTasks, ...details } = await fetchRoundDetails(
-      '0x381b50e8062757c404dec2bfae4da1b495341af9',
-      10,
+      '0xaaef78eaf86dcf34f275288752e892424dda9341',
+      410,
       recordTelemetry
     )
 
     assert.deepStrictEqual(details, {
-      roundId: '995' // BigInt serialized as String
+      roundId: '3408' // BigInt serialized as String
     })
 
-    assert.strictEqual(retrievalTasks.length, 30)
+    assert.strictEqual(retrievalTasks.length, 80)
     assert.deepStrictEqual(retrievalTasks.slice(0, 2), [
       {
-        cid: 'QmUen1QdStwcqYaRJKW59GfEk1y8TyqyrvisZ5Mm2ZwMhU',
-        protocol: 'bitswap',
-        providerAddress: '/dns4/elastic.dag.house/tcp/443/wss/p2p/QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC'
+        cid: 'QmQmAT34YQZUXWPonEBLYayGPqbfKT7WNVKyejYb8BfbJ8',
+        protocol: 'graphsync',
+        providerAddress: '/ip4/115.42.169.232/tcp/34568/p2p/12D3KooWH6ZS7VtsG8FWhxopQVSkvjMSbKtdiDgdfx7DR2oKopzV'
       },
       {
-        cid: 'bafybeidijvhvuvizg2ofeqos7l2kd4uanbawzx6qazyko5kbvth6dlhn5e',
-        protocol: 'bitswap',
-        providerAddress: '/dns4/elastic.dag.house/tcp/443/wss/p2p/QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC'
+        cid: 'bafybeift5kk74nwk6mezbicri23a5yvybdu63ege3c3jexxozfvhdd37s4',
+        protocol: 'graphsync',
+        providerAddress: '/ip4/103.145.73.12/tcp/41727/p2p/12D3KooWNo9msgn3T1uhmgxCjg5YKghMEHdNGr8uU4EtFC3a9zev'
       }
     ])
   })


### PR DESCRIPTION
The endpoint `/rounds/meridian/contract/index` does not support historic rounds.

The spark-api change:
- https://github.com/filecoin-station/spark-api/pull/147
