### PR TITLE
feat: report per-round retrieval stats to InfluxDB

### DIFF
--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -122,7 +122,13 @@ export const evaluate = async ({
     // }
   })
 
-  reportRetrievalStats(roundIndex, honestMeasurements, recordTelemetry)
+  recordTelemetry('retrieval_stats', (point) =>
+    reportRetrievalStats(roundIndex, honestMeasurements, point)
+  )
+
+  recordTelemetry('retrieval_stats_all', (point) =>
+    reportRetrievalStats(roundIndex, measurements, point)
+  )
 }
 
 /**
@@ -283,9 +289,9 @@ const calculateInetGroupSuccessRates = (taskGroups) => {
 /**
  * @param {bigint} roundIndex
  * @param {import('./typings').Measurement[]} measurements
- * @param {import('./typings').RecordTelemetryFn} recordTelemetry
+ * @param {import('./typings').Point} telemetryPoint
  */
-const reportRetrievalStats = (roundIndex, measurements, recordTelemetry) => {
+const reportRetrievalStats = (roundIndex, measurements, telemetryPoint) => {
   const totalCountOrOne = measurements.length || 1 // avoid division by zero
 
   const uniqueTasksCount = countUniqueTasks(measurements)
@@ -297,10 +303,7 @@ const reportRetrievalStats = (roundIndex, measurements, recordTelemetry) => {
     TIMEOUT: 0,
     CAR_TOO_LARGE: 0,
     BAD_GATEWAY: 0,
-    GATEWAY_TIMEOUT: 0,
-    SERVER_ERROR: 0,
-    UNKNOWN_ERROR: 0,
-    UNDEFINED: 0
+    GATEWAY_TIMEOUT: 0
   }
 
   for (const m of measurements) {
@@ -310,15 +313,13 @@ const reportRetrievalStats = (roundIndex, measurements, recordTelemetry) => {
   }
   const successRate = resultBreakdown.OK / totalCountOrOne
 
-  recordTelemetry('retrieval_stats', (point) => {
-    point.intField('round_index', roundIndex)
-    point.intField('unique_tasks', uniqueTasksCount)
-    point.floatField('success_rate', successRate)
+  telemetryPoint.intField('round_index', roundIndex)
+  telemetryPoint.intField('unique_tasks', uniqueTasksCount)
+  telemetryPoint.floatField('success_rate', successRate)
 
-    for (const [result, count] of Object.entries(resultBreakdown)) {
-      point.floatField(`result_rate_${result}`, count / totalCountOrOne)
-    }
-  })
+  for (const [result, count] of Object.entries(resultBreakdown)) {
+    telemetryPoint.floatField(`result_rate_${result}`, count / totalCountOrOne)
+  }
 }
 
 /**

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -1,5 +1,6 @@
 import createDebug from 'debug'
 import assert from 'node:assert'
+import * as Sentry from '@sentry/node'
 import { buildRetrievalStats } from './retrieval-stats.js'
 
 const debug = createDebug('spark:evaluate')
@@ -123,15 +124,25 @@ export const evaluate = async ({
     // }
   })
 
-  recordTelemetry('retrieval_stats_honest', (point) => {
-    point.intField('round_index', roundIndex)
-    buildRetrievalStats(honestMeasurements, point)
-  })
+  try {
+    recordTelemetry('retrieval_stats_honest', (point) => {
+      point.intField('round_index', roundIndex)
+      buildRetrievalStats(honestMeasurements, point)
+    })
+  } catch (err) {
+    console.error('Cannot record retrieval stats (honest).', err)
+    Sentry.captureException(err)
+  }
 
-  recordTelemetry('retrieval_stats_all', (point) => {
-    point.intField('round_index', roundIndex)
-    buildRetrievalStats(measurements, point)
-  })
+  try {
+    recordTelemetry('retrieval_stats_all', (point) => {
+      point.intField('round_index', roundIndex)
+      buildRetrievalStats(measurements, point)
+    })
+  } catch (err) {
+    console.error('Cannot record retrieval stats (all).', err)
+    Sentry.captureException(err)
+  }
 }
 
 /**

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -130,7 +130,7 @@ export const evaluate = async ({
     // }
   })
 
-  recordTelemetry('retrieval_stats', (point) => {
+  recordTelemetry('retrieval_stats_honest', (point) => {
     point.intField('round_index', roundIndex)
     reportRetrievalStats(honestMeasurements, point)
   })

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -322,8 +322,9 @@ const reportRetrievalStats = (roundIndex, measurements, telemetryPoint) => {
   telemetryPoint.intField('round_index', roundIndex)
   telemetryPoint.intField('unique_tasks', uniqueTasksCount)
   telemetryPoint.floatField('success_rate', successRate)
-  telemetryPoint.floatField('participants', participants.size)
-  telemetryPoint.floatField('inet_groups', inetGroups.size)
+  telemetryPoint.intField('participants', participants.size)
+  telemetryPoint.intField('inet_groups', inetGroups.size)
+  telemetryPoint.intField('measurements', measurements.length)
 
   for (const [result, count] of Object.entries(resultBreakdown)) {
     telemetryPoint.floatField(`result_rate_${result}`, count / totalCountOrOne)

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -345,17 +345,19 @@ const reportRetrievalStats = (measurements, telemetryPoint) => {
 
     // don't trust the checker to submit a positive integers
     // TODO: reject measurements with invalid values during the preprocess phase?
-    const size = typeof m.byte_length === 'number' && m.byte_length >= 0 ? m.byte_length : undefined
+    const byteLength = typeof m.byte_length === 'number' && m.byte_length >= 0
+      ? m.byte_length
+      : undefined
     const startAt = parseDateTime(m.start_at)
     const firstByteAt = parseDateTime(m.first_byte_at)
     const endAt = parseDateTime(m.end_at)
     const ttfb = startAt && firstByteAt && (firstByteAt - startAt)
     const duration = startAt && endAt && (endAt - startAt)
 
-    debug('size=%s ttfb=%s duration=%s valid? %s', size, ttfb, duration, m.fraudAssessment === 'OK')
-    if (size !== undefined) {
-      downloadBandwidth += size
-      sizeHistogram.recordValue(size)
+    debug('size=%s ttfb=%s duration=%s valid? %s', byteLength, ttfb, duration, m.fraudAssessment === 'OK')
+    if (byteLength !== undefined) {
+      downloadBandwidth += byteLength
+      sizeHistogram.recordValue(byteLength)
     }
     if (ttfb !== undefined) ttfbHistogram.recordValue(ttfb)
     if (duration !== undefined) durationHistogram.recordValue(duration)

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -306,16 +306,21 @@ const reportRetrievalStats = (roundIndex, measurements, telemetryPoint) => {
     GATEWAY_TIMEOUT: 0
   }
 
+  const participants = new Set()
+
   for (const m of measurements) {
     const result = m.retrievalResult ?? 'UNDEFINED'
     const oldCount = resultBreakdown[result] ?? 0
     resultBreakdown[result] = oldCount + 1
+
+    participants.add(m.participantAddress)
   }
   const successRate = resultBreakdown.OK / totalCountOrOne
 
   telemetryPoint.intField('round_index', roundIndex)
   telemetryPoint.intField('unique_tasks', uniqueTasksCount)
   telemetryPoint.floatField('success_rate', successRate)
+  telemetryPoint.floatField('participants', participants.size)
 
   for (const [result, count] of Object.entries(resultBreakdown)) {
     telemetryPoint.floatField(`result_rate_${result}`, count / totalCountOrOne)

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -311,6 +311,11 @@ const reportRetrievalStats = (measurements, telemetryPoint) => {
   const uniqueTasksCount = countUniqueTasks(measurements)
 
   // Calculate aggregates per retrieval result
+
+  // We are intentionally not initializing all possible keys here.
+  // Example of omitted keys: UNDEFINED, ERROR_500 and ERROR_404.
+  // The idea is that if we don't explicitly initialise them here and there is no measurement with
+  // such retrieval result, then the Grafana dashboard will not show these results at all.
   /** @type {Record<import('./typings').RetrievalResult, number> */
   const resultBreakdown = {
     OK: 0,
@@ -329,6 +334,8 @@ const reportRetrievalStats = (measurements, telemetryPoint) => {
   const sizeHistogram = createHistogram()
 
   for (const m of measurements) {
+    // `retrievalResult` should be always set by lib/preprocess.js, so we should never encounter
+    // `UNDEFINED` result. However, I am still handling that edge case for extra robustness.
     const result = m.retrievalResult ?? 'UNDEFINED'
     const oldCount = resultBreakdown[result] ?? 0
     resultBreakdown[result] = oldCount + 1

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -1,13 +1,6 @@
 import createDebug from 'debug'
 import assert from 'node:assert'
-import * as hdr from 'hdr-histogram-js'
-
-await hdr.initWebAssembly()
-const createHistogram = () => hdr.build({
-  numberOfSignificantValueDigits: 5,
-  bitBucketSize: 'packed',
-  useWebAssembly: true
-})
+import { buildRetrievalStats } from './retrieval-stats.js'
 
 const debug = createDebug('spark:evaluate')
 
@@ -132,12 +125,12 @@ export const evaluate = async ({
 
   recordTelemetry('retrieval_stats_honest', (point) => {
     point.intField('round_index', roundIndex)
-    reportRetrievalStats(honestMeasurements, point)
+    buildRetrievalStats(honestMeasurements, point)
   })
 
   recordTelemetry('retrieval_stats_all', (point) => {
     point.intField('round_index', roundIndex)
-    reportRetrievalStats(measurements, point)
+    buildRetrievalStats(measurements, point)
   })
 }
 
@@ -294,132 +287,4 @@ const calculateInetGroupSuccessRates = (taskGroups) => {
   result.mean = sum / participantStats.size
 
   return result
-}
-
-/**
- * @param {import('./typings').Measurement[]} measurements
- * @param {import('./typings').Point} telemetryPoint
- */
-const reportRetrievalStats = (measurements, telemetryPoint) => {
-  const totalCount = measurements.length
-  if (totalCount < 1) {
-    telemetryPoint.intField('measurements', 0)
-    telemetryPoint.intField('unique_tasks', 0)
-    return
-  }
-
-  const uniqueTasksCount = countUniqueTasks(measurements)
-
-  // Calculate aggregates per retrieval result
-
-  // We are intentionally not initializing all possible keys here.
-  // Example of omitted keys: UNDEFINED, ERROR_500 and ERROR_404.
-  // The idea is that if we don't explicitly initialise them here and there is no measurement with
-  // such retrieval result, then the Grafana dashboard will not show these results at all.
-  /** @type {Record<import('./typings').RetrievalResult, number> */
-  const resultBreakdown = {
-    OK: 0,
-    TIMEOUT: 0,
-    CAR_TOO_LARGE: 0,
-    BAD_GATEWAY: 0,
-    GATEWAY_TIMEOUT: 0
-  }
-
-  const participants = new Set()
-  const inetGroups = new Set()
-  let downloadBandwidth = 0
-
-  const ttfbHistogram = createHistogram()
-  const durationHistogram = createHistogram()
-  const sizeHistogram = createHistogram()
-
-  for (const m of measurements) {
-    // `retrievalResult` should be always set by lib/preprocess.js, so we should never encounter
-    // `UNDEFINED` result. However, I am still handling that edge case for extra robustness.
-    const result = m.retrievalResult ?? 'UNDEFINED'
-    const oldCount = resultBreakdown[result] ?? 0
-    resultBreakdown[result] = oldCount + 1
-
-    participants.add(m.participantAddress)
-    inetGroups.add(m.inet_group)
-
-    // don't trust the checker to submit a positive integers
-    // TODO: reject measurements with invalid values during the preprocess phase?
-    const byteLength = typeof m.byte_length === 'number' && m.byte_length >= 0
-      ? m.byte_length
-      : undefined
-    const startAt = parseDateTime(m.start_at)
-    const firstByteAt = parseDateTime(m.first_byte_at)
-    const endAt = parseDateTime(m.end_at)
-    const ttfb = startAt && firstByteAt && (firstByteAt - startAt)
-    const duration = startAt && endAt && (endAt - startAt)
-
-    debug('size=%s ttfb=%s duration=%s valid? %s', byteLength, ttfb, duration, m.fraudAssessment === 'OK')
-    if (byteLength !== undefined) {
-      downloadBandwidth += byteLength
-      sizeHistogram.recordValue(byteLength)
-    }
-    if (ttfb !== undefined) ttfbHistogram.recordValue(ttfb)
-    if (duration !== undefined) durationHistogram.recordValue(duration)
-  }
-  const successRate = resultBreakdown.OK / totalCount
-
-  telemetryPoint.intField('unique_tasks', uniqueTasksCount)
-  telemetryPoint.floatField('success_rate', successRate)
-  telemetryPoint.intField('participants', participants.size)
-  telemetryPoint.intField('inet_groups', inetGroups.size)
-  telemetryPoint.intField('measurements', totalCount)
-  telemetryPoint.intField('download_bandwidth', downloadBandwidth)
-
-  addHistogramToPoint(telemetryPoint, 'ttfb', ttfbHistogram)
-  ttfbHistogram.destroy()
-
-  addHistogramToPoint(telemetryPoint, 'duration', durationHistogram)
-  durationHistogram.destroy()
-
-  addHistogramToPoint(telemetryPoint, 'car_size', sizeHistogram)
-  sizeHistogram.destroy()
-
-  for (const [result, count] of Object.entries(resultBreakdown)) {
-    telemetryPoint.floatField(`result_rate_${result}`, count / totalCount)
-  }
-}
-
-const parseDateTime = (str) => {
-  if (!str) return undefined
-  const value = new Date(str)
-  if (Number.isNaN(value.getTime())) return undefined
-  return value
-}
-
-/**
- *
- * @param {import('./typings').Point} point
- * @param {string} fieldNamePrefix
- * @param {hdr.Histogram} histogram
- */
-const addHistogramToPoint = (point, fieldNamePrefix, histogram) => {
-  point.intField(`${fieldNamePrefix}_min`, histogram.minNonZeroValue)
-  point.intField(`${fieldNamePrefix}_mean`, histogram.mean)
-  point.intField(`${fieldNamePrefix}_max`, histogram.maxValue)
-  for (const p of [10, 50, 90, 95]) {
-    point.intField(`${fieldNamePrefix}_p${p}`, histogram.getValueAtPercentile(p))
-  }
-}
-
-/**
- * @param {import('./typings').Measurement[]} measurements
- * @returns {number}
- */
-const countUniqueTasks = (measurements) => {
-  const getTaskId = (/** @type {import('./typings').Measurement} */m) =>
-    `${m.cid}::${m.protocol}::${m.provider_address}`
-
-  const uniqueTasks = new Set()
-  for (const m of measurements) {
-    const id = getTaskId(m)
-    uniqueTasks.add(id)
-  }
-
-  return uniqueTasks.size
 }

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -307,6 +307,7 @@ const reportRetrievalStats = (roundIndex, measurements, telemetryPoint) => {
   }
 
   const participants = new Set()
+  const inetGroups = new Set()
 
   for (const m of measurements) {
     const result = m.retrievalResult ?? 'UNDEFINED'
@@ -314,6 +315,7 @@ const reportRetrievalStats = (roundIndex, measurements, telemetryPoint) => {
     resultBreakdown[result] = oldCount + 1
 
     participants.add(m.participantAddress)
+    inetGroups.add(m.inet_group)
   }
   const successRate = resultBreakdown.OK / totalCountOrOne
 
@@ -321,6 +323,7 @@ const reportRetrievalStats = (roundIndex, measurements, telemetryPoint) => {
   telemetryPoint.intField('unique_tasks', uniqueTasksCount)
   telemetryPoint.floatField('success_rate', successRate)
   telemetryPoint.floatField('participants', participants.size)
+  telemetryPoint.floatField('inet_groups', inetGroups.size)
 
   for (const [result, count] of Object.entries(resultBreakdown)) {
     telemetryPoint.floatField(`result_rate_${result}`, count / totalCountOrOne)

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -303,7 +303,7 @@ const calculateInetGroupSuccessRates = (taskGroups) => {
 const reportRetrievalStats = (measurements, telemetryPoint) => {
   const totalCount = measurements.length
   if (totalCount < 1) {
-    telemetryPoint.intField('measurements', totalCount)
+    telemetryPoint.intField('measurements', 0)
     telemetryPoint.intField('unique_tasks', 0)
     return
   }

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -1,5 +1,13 @@
 import createDebug from 'debug'
 import assert from 'node:assert'
+import * as hdr from 'hdr-histogram-js'
+
+await hdr.initWebAssembly()
+const createHistogram = () => hdr.build({
+  numberOfSignificantValueDigits: 5,
+  bitBucketSize: 'packed',
+  useWebAssembly: true
+})
 
 const debug = createDebug('spark:evaluate')
 
@@ -122,13 +130,15 @@ export const evaluate = async ({
     // }
   })
 
-  recordTelemetry('retrieval_stats', (point) =>
-    reportRetrievalStats(roundIndex, honestMeasurements, point)
-  )
+  recordTelemetry('retrieval_stats', (point) => {
+    point.intField('round_index', roundIndex)
+    reportRetrievalStats(honestMeasurements, point)
+  })
 
-  recordTelemetry('retrieval_stats_all', (point) =>
-    reportRetrievalStats(roundIndex, measurements, point)
-  )
+  recordTelemetry('retrieval_stats_all', (point) => {
+    point.intField('round_index', roundIndex)
+    reportRetrievalStats(measurements, point)
+  })
 }
 
 /**
@@ -287,12 +297,16 @@ const calculateInetGroupSuccessRates = (taskGroups) => {
 }
 
 /**
- * @param {bigint} roundIndex
  * @param {import('./typings').Measurement[]} measurements
  * @param {import('./typings').Point} telemetryPoint
  */
-const reportRetrievalStats = (roundIndex, measurements, telemetryPoint) => {
-  const totalCountOrOne = measurements.length || 1 // avoid division by zero
+const reportRetrievalStats = (measurements, telemetryPoint) => {
+  const totalCount = measurements.length
+  if (totalCount < 1) {
+    telemetryPoint.intField('measurements', totalCount)
+    telemetryPoint.intField('unique_tasks', 0)
+    return
+  }
 
   const uniqueTasksCount = countUniqueTasks(measurements)
 
@@ -308,6 +322,11 @@ const reportRetrievalStats = (roundIndex, measurements, telemetryPoint) => {
 
   const participants = new Set()
   const inetGroups = new Set()
+  let downloadBandwidth = 0
+
+  const ttfbHistogram = createHistogram()
+  const durationHistogram = createHistogram()
+  const sizeHistogram = createHistogram()
 
   for (const m of measurements) {
     const result = m.retrievalResult ?? 'UNDEFINED'
@@ -316,18 +335,66 @@ const reportRetrievalStats = (roundIndex, measurements, telemetryPoint) => {
 
     participants.add(m.participantAddress)
     inetGroups.add(m.inet_group)
-  }
-  const successRate = resultBreakdown.OK / totalCountOrOne
 
-  telemetryPoint.intField('round_index', roundIndex)
+    // don't trust the checker to submit a positive integers
+    // TODO: reject measurements with invalid values during the preprocess phase?
+    const size = typeof m.byte_length === 'number' && m.byte_length >= 0 ? m.byte_length : undefined
+    const startAt = parseDateTime(m.start_at)
+    const firstByteAt = parseDateTime(m.first_byte_at)
+    const endAt = parseDateTime(m.end_at)
+    const ttfb = startAt && firstByteAt && (firstByteAt - startAt)
+    const duration = startAt && endAt && (endAt - startAt)
+
+    debug('size=%s ttfb=%s duration=%s valid? %s', size, ttfb, duration, m.fraudAssessment === 'OK')
+    if (size !== undefined) {
+      downloadBandwidth += size
+      sizeHistogram.recordValue(size)
+    }
+    if (ttfb !== undefined) ttfbHistogram.recordValue(ttfb)
+    if (duration !== undefined) durationHistogram.recordValue(duration)
+  }
+  const successRate = resultBreakdown.OK / totalCount
+
   telemetryPoint.intField('unique_tasks', uniqueTasksCount)
   telemetryPoint.floatField('success_rate', successRate)
   telemetryPoint.intField('participants', participants.size)
   telemetryPoint.intField('inet_groups', inetGroups.size)
-  telemetryPoint.intField('measurements', measurements.length)
+  telemetryPoint.intField('measurements', totalCount)
+  telemetryPoint.intField('download_bandwidth', downloadBandwidth)
+
+  addHistogramToPoint(telemetryPoint, 'ttfb', ttfbHistogram)
+  ttfbHistogram.destroy()
+
+  addHistogramToPoint(telemetryPoint, 'duration', durationHistogram)
+  durationHistogram.destroy()
+
+  addHistogramToPoint(telemetryPoint, 'car_size', sizeHistogram)
+  sizeHistogram.destroy()
 
   for (const [result, count] of Object.entries(resultBreakdown)) {
-    telemetryPoint.floatField(`result_rate_${result}`, count / totalCountOrOne)
+    telemetryPoint.floatField(`result_rate_${result}`, count / totalCount)
+  }
+}
+
+const parseDateTime = (str) => {
+  if (!str) return undefined
+  const value = new Date(str)
+  if (Number.isNaN(value.getTime())) return undefined
+  return value
+}
+
+/**
+ *
+ * @param {import('./typings').Point} point
+ * @param {string} fieldNamePrefix
+ * @param {hdr.Histogram} histogram
+ */
+const addHistogramToPoint = (point, fieldNamePrefix, histogram) => {
+  point.intField(`${fieldNamePrefix}_min`, histogram.minNonZeroValue)
+  point.intField(`${fieldNamePrefix}_mean`, histogram.mean)
+  point.intField(`${fieldNamePrefix}_max`, histogram.maxValue)
+  for (const p of [10, 50, 90, 95]) {
+    point.intField(`${fieldNamePrefix}_p${p}`, histogram.getValueAtPercentile(p))
   }
 }
 

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -110,7 +110,6 @@ export const evaluate = async ({
     point.intField('total_participants', Object.keys(participants).length)
     point.intField('total_measurements', measurements.length)
     point.intField('honest_measurements', honestMeasurements.length)
-    point.intField('unique_tasks', countUniqueTasks(honestMeasurements))
     point.intField('set_scores_duration_ms', setScoresDuration)
 
     for (const [type, count] of Object.entries(fraudAssessments)) {
@@ -122,6 +121,8 @@ export const evaluate = async ({
     //   point.floatField(`group_winning_${key}`, value)
     // }
   })
+
+  reportRetrievalStats(roundIndex, honestMeasurements, recordTelemetry)
 }
 
 /**
@@ -277,6 +278,47 @@ const calculateInetGroupSuccessRates = (taskGroups) => {
   result.mean = sum / participantStats.size
 
   return result
+}
+
+/**
+ * @param {bigint} roundIndex
+ * @param {import('./typings').Measurement[]} measurements
+ * @param {import('./typings').RecordTelemetryFn} recordTelemetry
+ */
+const reportRetrievalStats = (roundIndex, measurements, recordTelemetry) => {
+  const totalCountOrOne = measurements.length || 1 // avoid division by zero
+
+  const uniqueTasksCount = countUniqueTasks(measurements)
+
+  // Calculate aggregates per retrieval result
+  /** @type {Record<import('./typings').RetrievalResult, number> */
+  const resultBreakdown = {
+    OK: 0,
+    TIMEOUT: 0,
+    CAR_TOO_LARGE: 0,
+    BAD_GATEWAY: 0,
+    GATEWAY_TIMEOUT: 0,
+    SERVER_ERROR: 0,
+    UNKNOWN_ERROR: 0,
+    UNDEFINED: 0
+  }
+
+  for (const m of measurements) {
+    const result = m.retrievalResult ?? 'UNDEFINED'
+    const oldCount = resultBreakdown[result] ?? 0
+    resultBreakdown[result] = oldCount + 1
+  }
+  const successRate = resultBreakdown.OK / totalCountOrOne
+
+  recordTelemetry('retrieval_stats', (point) => {
+    point.intField('round_index', roundIndex)
+    point.intField('unique_tasks', uniqueTasksCount)
+    point.floatField('success_rate', successRate)
+
+    for (const [result, count] of Object.entries(resultBreakdown)) {
+      point.floatField(`result_rate_${result}`, count / totalCountOrOne)
+    }
+  })
 }
 
 /**

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -133,11 +133,9 @@ export const calculateRetrievalResult = measurement => {
     case 502: return 'BAD_GATEWAY'
     case 504: return 'GATEWAY_TIMEOUT'
   }
-  if (measurement.status_code >= 500) return 'SERVER_ERROR'
+  if (measurement.status_code >= 300) return `ERROR_${measurement.status_code}`
 
-  const ok = measurement.status_code >= 200 &&
-    measurement.status_code < 300 &&
-    typeof measurement.end_at === 'string'
+  const ok = typeof measurement.end_at === 'string'
 
   return ok ? 'OK' : 'UNKNOWN_ERROR'
 }

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -24,7 +24,7 @@ export const preprocess = async ({
         return {
           ...measurement,
           participantAddress: parseParticipantAddress(participant_address),
-          retrievalResult: calculateRetrievalResult(measurement)
+          retrievalResult: getRetrievalResult(measurement)
         }
       } catch (err) {
         logger.error('Invalid measurement:', err.message, measurement)
@@ -124,7 +124,7 @@ const assertValidMeasurement = measurement => {
  * @param {import('./typings').Measurement} measurement
  * @return {import('./typings').RetrievalResult}
  */
-export const calculateRetrievalResult = measurement => {
+export const getRetrievalResult = measurement => {
   if (measurement.timeout) return 'TIMEOUT'
   if (measurement.car_too_large) return 'CAR_TOO_LARGE'
   switch (measurement.status_code) {

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -1,6 +1,9 @@
 import assert from 'node:assert'
 import { ethers } from 'ethers'
 import { ethAddressFromDelegated } from '@glif/filecoin-address'
+import createDebug from 'debug'
+
+const debug = createDebug('spark:preprocess')
 
 export const preprocess = async ({
   rounds,
@@ -11,6 +14,7 @@ export const preprocess = async ({
   logger
 }) => {
   const start = new Date()
+  /** @type import('./typings').Measurement[] */
   const measurements = await fetchMeasurements(cid)
   const fetchDuration = new Date() - start
   const validMeasurements = measurements
@@ -19,7 +23,8 @@ export const preprocess = async ({
       try {
         return {
           ...measurement,
-          participantAddress: parseParticipantAddress(participant_address)
+          participantAddress: parseParticipantAddress(participant_address),
+          retrievalResult: calculateRetrievalResult(measurement)
         }
       } catch (err) {
         logger.error('Invalid measurement:', err.message, measurement)
@@ -28,6 +33,19 @@ export const preprocess = async ({
     })
     .filter(measurement => {
       if (measurement === null) return false
+
+      if (debug.enabled) {
+        // Print round & participant address & CID together to simplify lookup when debugging
+        // Omit the `m` object from the format string to get nicer formatting
+        debug(
+          'RETRIEVAL RESULT for round=%s client=%s cid=%s: %s',
+          roundIndex,
+          measurement.participantAddress,
+          measurement.cid,
+          measurement.retrievalResult,
+          measurement)
+      }
+
       try {
         assertValidMeasurement(measurement)
         return true
@@ -102,4 +120,24 @@ const assertValidMeasurement = measurement => {
   assert(ethers.utils.isAddress(measurement.participantAddress), 'valid participant address required')
   assert(typeof measurement.inet_group === 'string', 'valid inet group required')
   assert(typeof measurement.finished_at === 'string', 'field `finished_at` must be set to a string')
+}
+
+/**
+ * @param {import('./typings').Measurement} measurement
+ * @return {import('./typings').RetrievalResult}
+ */
+export const calculateRetrievalResult = measurement => {
+  if (measurement.timeout) return 'TIMEOUT'
+  if (measurement.car_too_large) return 'CAR_TOO_LARGE'
+  switch (measurement.status_code) {
+    case 502: return 'BAD_GATEWAY'
+    case 504: return 'GATEWAY_TIMEOUT'
+  }
+  if (measurement.status_code >= 500) return 'SERVER_ERROR'
+
+  const ok = measurement.status_code >= 200 &&
+    measurement.status_code < 300 &&
+    typeof measurement.end_at === 'string'
+
+  return ok ? 'OK' : 'UNKNOWN_ERROR'
 }

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -34,17 +34,15 @@ export const preprocess = async ({
     .filter(measurement => {
       if (measurement === null) return false
 
-      if (debug.enabled) {
-        // Print round & participant address & CID together to simplify lookup when debugging
-        // Omit the `m` object from the format string to get nicer formatting
-        debug(
-          'RETRIEVAL RESULT for round=%s client=%s cid=%s: %s',
-          roundIndex,
-          measurement.participantAddress,
-          measurement.cid,
-          measurement.retrievalResult,
-          measurement)
-      }
+      // Print round & participant address & CID together to simplify lookup when debugging
+      // Omit the `m` object from the format string to get nicer formatting
+      debug(
+        'RETRIEVAL RESULT for round=%s client=%s cid=%s: %s',
+        roundIndex,
+        measurement.participantAddress,
+        measurement.cid,
+        measurement.retrievalResult,
+        measurement)
 
       try {
         assertValidMeasurement(measurement)

--- a/lib/retrieval-stats.js
+++ b/lib/retrieval-stats.js
@@ -1,0 +1,139 @@
+import createDebug from 'debug'
+import * as hdr from 'hdr-histogram-js'
+
+const debug = createDebug('spark:retrieval-stats')
+
+await hdr.initWebAssembly()
+const createHistogram = () => hdr.build({
+  numberOfSignificantValueDigits: 5,
+  bitBucketSize: 'packed',
+  useWebAssembly: true
+})
+
+/**
+ * @param {import('./typings').Measurement[]} measurements
+ * @param {import('./typings').Point} telemetryPoint
+ */
+export const buildRetrievalStats = (measurements, telemetryPoint) => {
+  const totalCount = measurements.length
+  if (totalCount < 1) {
+    telemetryPoint.intField('measurements', 0)
+    telemetryPoint.intField('unique_tasks', 0)
+    return
+  }
+
+  const uniqueTasksCount = countUniqueTasks(measurements)
+
+  // Calculate aggregates per retrieval result
+
+  // We are intentionally not initializing all possible keys here.
+  // Example of omitted keys: UNDEFINED, ERROR_500 and ERROR_404.
+  // The idea is that if we don't explicitly initialise them here and there is no measurement with
+  // such retrieval result, then the Grafana dashboard will not show these results at all.
+  /** @type {Record<import('./typings').RetrievalResult, number> */
+  const resultBreakdown = {
+    OK: 0,
+    TIMEOUT: 0,
+    CAR_TOO_LARGE: 0,
+    BAD_GATEWAY: 0,
+    GATEWAY_TIMEOUT: 0
+  }
+
+  const participants = new Set()
+  const inetGroups = new Set()
+  let downloadBandwidth = 0
+
+  const ttfbHistogram = createHistogram()
+  const durationHistogram = createHistogram()
+  const sizeHistogram = createHistogram()
+
+  for (const m of measurements) {
+    // `retrievalResult` should be always set by lib/preprocess.js, so we should never encounter
+    // `UNDEFINED` result. However, I am still handling that edge case for extra robustness.
+    const result = m.retrievalResult ?? 'UNDEFINED'
+    const oldCount = resultBreakdown[result] ?? 0
+    resultBreakdown[result] = oldCount + 1
+
+    participants.add(m.participantAddress)
+    inetGroups.add(m.inet_group)
+
+    // don't trust the checker to submit a positive integers
+    // TODO: reject measurements with invalid values during the preprocess phase?
+    const byteLength = typeof m.byte_length === 'number' && m.byte_length >= 0
+      ? m.byte_length
+      : undefined
+    const startAt = parseDateTime(m.start_at)
+    const firstByteAt = parseDateTime(m.first_byte_at)
+    const endAt = parseDateTime(m.end_at)
+    const ttfb = startAt && firstByteAt && (firstByteAt - startAt)
+    const duration = startAt && endAt && (endAt - startAt)
+
+    debug('size=%s ttfb=%s duration=%s valid? %s', byteLength, ttfb, duration, m.fraudAssessment === 'OK')
+    if (byteLength !== undefined) {
+      downloadBandwidth += byteLength
+      sizeHistogram.recordValue(byteLength)
+    }
+    if (ttfb !== undefined) ttfbHistogram.recordValue(ttfb)
+    if (duration !== undefined) durationHistogram.recordValue(duration)
+  }
+  const successRate = resultBreakdown.OK / totalCount
+
+  telemetryPoint.intField('unique_tasks', uniqueTasksCount)
+  telemetryPoint.floatField('success_rate', successRate)
+  telemetryPoint.intField('participants', participants.size)
+  telemetryPoint.intField('inet_groups', inetGroups.size)
+  telemetryPoint.intField('measurements', totalCount)
+  telemetryPoint.intField('download_bandwidth', downloadBandwidth)
+
+  addHistogramToPoint(telemetryPoint, 'ttfb', ttfbHistogram)
+  ttfbHistogram.destroy()
+
+  addHistogramToPoint(telemetryPoint, 'duration', durationHistogram)
+  durationHistogram.destroy()
+
+  addHistogramToPoint(telemetryPoint, 'car_size', sizeHistogram)
+  sizeHistogram.destroy()
+
+  for (const [result, count] of Object.entries(resultBreakdown)) {
+    telemetryPoint.floatField(`result_rate_${result}`, count / totalCount)
+  }
+}
+
+const parseDateTime = (str) => {
+  if (!str) return undefined
+  const value = new Date(str)
+  if (Number.isNaN(value.getTime())) return undefined
+  return value
+}
+
+/**
+ *
+ * @param {import('./typings').Point} point
+ * @param {string} fieldNamePrefix
+ * @param {hdr.Histogram} histogram
+ */
+const addHistogramToPoint = (point, fieldNamePrefix, histogram) => {
+  point.intField(`${fieldNamePrefix}_min`, histogram.minNonZeroValue)
+  point.intField(`${fieldNamePrefix}_mean`, histogram.mean)
+  point.intField(`${fieldNamePrefix}_max`, histogram.maxValue)
+  for (const p of [10, 50, 90, 95]) {
+    point.intField(`${fieldNamePrefix}_p${p}`, histogram.getValueAtPercentile(p))
+  }
+}
+
+/**
+ * @param {import('./typings').Measurement[]} measurements
+ * @returns {number}
+ */
+const countUniqueTasks = (measurements) => {
+  const getTaskId = (/** @type {import('./typings').Measurement} */m) =>
+    `${m.cid}::${m.protocol}::${m.provider_address}`
+
+  const uniqueTasks = new Set()
+  for (const m of measurements) {
+    const id = getTaskId(m)
+    uniqueTasks.add(id)
+  }
+
+  return uniqueTasks.size
+}

--- a/lib/typings.d.ts
+++ b/lib/typings.d.ts
@@ -61,6 +61,7 @@ export interface Measurement {
 
   status_code: number;
   timeout: boolean;
+  byte_length: number;
   car_too_large: boolean;
 }
 

--- a/lib/typings.d.ts
+++ b/lib/typings.d.ts
@@ -1,5 +1,10 @@
 import { Point } from '@influxdata/influxdb-client'
 
+export {
+  Point
+}
+
+
 /**
  * Details of a retrieval task as returned by SPARK HTTP API.
  */
@@ -36,7 +41,7 @@ export type RetrievalResult =
   | 'CAR_TOO_LARGE'
   | 'BAD_GATEWAY'
   | 'GATEWAY_TIMEOUT'
-  | 'SERVER_ERROR'
+  | 'ERROR_500'
   | 'UNKNOWN_ERROR'
 
 export interface Measurement {

--- a/lib/typings.d.ts
+++ b/lib/typings.d.ts
@@ -28,9 +28,21 @@ export type FraudAssesment =
   | 'INVALID_TASK'
   | 'DUP_INET_GROUP'
 
+
+// When adding a new enum value, remember to update the summary initializer inside `reportRetrievalStats()`
+export type RetrievalResult =
+  | 'OK'
+  | 'TIMEOUT'
+  | 'CAR_TOO_LARGE'
+  | 'BAD_GATEWAY'
+  | 'GATEWAY_TIMEOUT'
+  | 'SERVER_ERROR'
+  | 'UNKNOWN_ERROR'
+
 export interface Measurement {
   participantAddress: string;
   fraudAssessment?: FraudAssesment;
+  retrievalResult?: RetrievalResult;
 
   cid: string;
   provider_address: string;
@@ -41,6 +53,10 @@ export interface Measurement {
   first_byte_at: string;
   end_at: string;
   finished_at: string;
+
+  status_code: number;
+  timeout: boolean;
+  car_too_large: boolean;
 }
 
 export interface GroupWinningStats {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@sentry/node": "^7.81.1",
         "debug": "^4.3.4",
         "ethers": "^5.7.2",
+        "hdr-histogram-js": "^3.0.0",
         "web3.storage": "^4.5.5"
       },
       "devDependencies": {
@@ -3221,6 +3222,24 @@
         "minimalistic-assert": "^1.0.1"
       }
     },
+    "node_modules/hdr-histogram-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-js/-/hdr-histogram-js-3.0.0.tgz",
+      "integrity": "sha512-/EpvQI2/Z98mNFYEnlqJ8Ogful8OpArLG/6Tf2bPnkutBVLIeMVNHjk1ZDfshF2BUweipzbk+dB1hgSB7SIakw==",
+      "dependencies": {
+        "@assemblyscript/loader": "^0.19.21",
+        "base64-js": "^1.2.0",
+        "pako": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/hdr-histogram-js/node_modules/@assemblyscript/loader": {
+      "version": "0.19.23",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.19.23.tgz",
+      "integrity": "sha512-ulkCYfFbYj01ie1MDOyxv2F6SpRN1TOj7fQxbP07D6HmeR+gr2JLSmINKjga2emB+b1L2KGrFKBTc+e00p54nw=="
+    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -4970,6 +4989,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@sentry/node": "^7.81.1",
     "debug": "^4.3.4",
     "ethers": "^5.7.2",
+    "hdr-histogram-js": "^3.0.0",
     "web3.storage": "^4.5.5"
   },
   "standard": {

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -237,6 +237,7 @@ describe('evaluate', () => {
         ...VALID_MEASUREMENT,
         status_code: 500,
         retrievalResult: 'ERROR_500',
+        participantAddress: '0xcheater',
         // invalid task
         cid: 'bafyinvalid',
         provider_address: '/dns4/production-ipfs-peer.pinata.cloud/tcp/3000/ws/p2p/Qma8ddFEQWEU8ijWvdxXm3nxU7oHsRtCykAaVz8WUYhiKn',
@@ -269,12 +270,14 @@ describe('evaluate', () => {
       `No telemetry point "retrieval_stats" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
     assertPointFieldValue(point, 'unique_tasks', '1i')
     assertPointFieldValue(point, 'success_rate', '1')
+    assertPointFieldValue(point, 'participants', '1')
 
     point = telemetry.find(p => p.name === 'retrieval_stats_all')
     assert(!!point,
       `No telemetry point "retrieval_stats_all" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
     assertPointFieldValue(point, 'unique_tasks', '2i')
     assertPointFieldValue(point, 'success_rate', '0.5')
+    assertPointFieldValue(point, 'participants', '2')
   })
 })
 

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -26,14 +26,21 @@ const VALID_TASK = {
 }
 Object.freeze(VALID_TASK)
 
+/** @type {import('../lib/typings').Measurement} */
 const VALID_MEASUREMENT = {
   cid: VALID_TASK.cid,
   provider_address: VALID_TASK.providerAddress,
   protocol: VALID_TASK.protocol,
   participantAddress: VALID_PARTICIPANT_ADDRESS,
   inet_group: 'some-group-id',
-  finished_at: '2023-11-01T09:00:00.000Z'
+  status_code: 200,
+  timeout: false,
+  car_too_large: false,
+  end_at: '2023-11-01T09:00:00.000Z',
+  finished_at: '2023-11-01T09:00:10.000Z',
+  retrievalResult: 'OK'
 }
+
 // Fraud detection is mutating the measurements parsed from JSON
 // To prevent tests from accidentally mutating data used by subsequent tests,
 // we freeze this test data object. If we forget to clone this default measurement
@@ -72,10 +79,16 @@ describe('evaluate', () => {
       BigNumber.from(1_000_000_000_000_000).toString()
     )
 
-    const point = telemetry.find(p => p.name === 'evaluate')
+    let point = telemetry.find(p => p.name === 'evaluate')
     assert(!!point,
       `No telemetry point "evaluate" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
+    // TODO: assert point fields
+
+    point = telemetry.find(p => p.name === 'retrieval_stats')
+    assert(!!point,
+      `No telemetry point "retrieval_stats" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
     assert.strictEqual(point.fields.unique_tasks, '1i')
+    assert.strictEqual(point.fields.success_rate, '1')
   })
   it('handles empty rounds', async () => {
     const rounds = { 0: [] }
@@ -104,9 +117,14 @@ describe('evaluate', () => {
       MAX_SCORE
     ])
 
-    const point = telemetry.find(p => p.name === 'evaluate')
+    let point = telemetry.find(p => p.name === 'evaluate')
     assert(!!point,
       `No telemetry point "evaluate" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
+    // TODO: assert point fields
+
+    point = telemetry.find(p => p.name === 'retrieval_stats')
+    assert(!!point,
+          `No telemetry point "retrieval_stats" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
     assert.strictEqual(point.fields.unique_tasks, '0i')
   })
   it('handles unknown rounds', async () => {

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -36,8 +36,11 @@ const VALID_MEASUREMENT = {
   status_code: 200,
   timeout: false,
   car_too_large: false,
-  end_at: '2023-11-01T09:00:00.000Z',
+  start_at: '2023-11-01T09:00:00.000Z',
+  first_byte_at: '2023-11-01T09:00:01.000Z',
+  end_at: '2023-11-01T09:00:02.000Z',
   finished_at: '2023-11-01T09:00:10.000Z',
+  byte_length: 1024,
   retrievalResult: 'OK'
 }
 
@@ -125,7 +128,14 @@ describe('evaluate', () => {
     point = telemetry.find(p => p.name === 'retrieval_stats')
     assert(!!point,
           `No telemetry point "retrieval_stats" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
+    assertPointFieldValue(point, 'measurements', '0i')
     assertPointFieldValue(point, 'unique_tasks', '0i')
+    // no more fields are set for empty rounds
+    assert.deepStrictEqual(Object.keys(point.fields), [
+      'round_index',
+      'measurements',
+      'unique_tasks'
+    ])
   })
   it('handles unknown rounds', async () => {
     const rounds = {}
@@ -239,6 +249,12 @@ describe('evaluate', () => {
         retrievalResult: 'ERROR_500',
         participantAddress: '0xcheater',
         inet_group: 'abcd',
+        start_at: '2023-11-01T09:00:00.000Z',
+        first_byte_at: '2023-11-01T09:00:10.000Z',
+        end_at: '2023-11-01T09:00:20.000Z',
+        finished_at: '2023-11-01T09:00:30.000Z',
+        byte_length: 2048,
+
         // invalid task
         cid: 'bafyinvalid',
         provider_address: '/dns4/production-ipfs-peer.pinata.cloud/tcp/3000/ws/p2p/Qma8ddFEQWEU8ijWvdxXm3nxU7oHsRtCykAaVz8WUYhiKn',
@@ -269,27 +285,57 @@ describe('evaluate', () => {
     let point = telemetry.find(p => p.name === 'retrieval_stats')
     assert(!!point,
       `No telemetry point "retrieval_stats" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
+    debug(point.name, point.fields)
+
     assertPointFieldValue(point, 'unique_tasks', '1i')
     assertPointFieldValue(point, 'success_rate', '1')
     assertPointFieldValue(point, 'participants', '1i')
     assertPointFieldValue(point, 'inet_groups', '1i')
     assertPointFieldValue(point, 'measurements', '1i')
+    assertPointFieldValue(point, 'download_bandwidth', '1024i')
 
     assertPointFieldValue(point, 'result_rate_OK', '1')
     assertPointFieldValue(point, 'result_rate_TIMEOUT', '0')
 
+    assertPointFieldValue(point, 'ttfb_p10', '1000i')
+    assertPointFieldValue(point, 'ttfb_mean', '1000i')
+    assertPointFieldValue(point, 'ttfb_p90', '1000i')
+
+    assertPointFieldValue(point, 'duration_p10', '2000i')
+    assertPointFieldValue(point, 'duration_mean', '2000i')
+    assertPointFieldValue(point, 'duration_p90', '2000i')
+
+    assertPointFieldValue(point, 'car_size_p10', '1024i')
+    assertPointFieldValue(point, 'car_size_mean', '1024i')
+    assertPointFieldValue(point, 'car_size_p90', '1024i')
+
     point = telemetry.find(p => p.name === 'retrieval_stats_all')
     assert(!!point,
       `No telemetry point "retrieval_stats_all" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
+    debug(point.name, point.fields)
+
     assertPointFieldValue(point, 'unique_tasks', '2i')
     assertPointFieldValue(point, 'success_rate', '0.5')
     assertPointFieldValue(point, 'participants', '2i')
     assertPointFieldValue(point, 'inet_groups', '2i')
     assertPointFieldValue(point, 'measurements', '2i')
+    assertPointFieldValue(point, 'download_bandwidth', '3072i')
 
     assertPointFieldValue(point, 'result_rate_OK', '0.5')
     assertPointFieldValue(point, 'result_rate_TIMEOUT', '0')
     assertPointFieldValue(point, 'result_rate_ERROR_500', '0.5')
+
+    assertPointFieldValue(point, 'ttfb_min', '1000i')
+    assertPointFieldValue(point, 'ttfb_mean', '5500i')
+    assertPointFieldValue(point, 'ttfb_p90', '10000i')
+
+    assertPointFieldValue(point, 'duration_p10', '2000i')
+    assertPointFieldValue(point, 'duration_mean', '11000i')
+    assertPointFieldValue(point, 'duration_p90', '20000i')
+
+    assertPointFieldValue(point, 'car_size_p10', '1024i')
+    assertPointFieldValue(point, 'car_size_mean', '1536i')
+    assertPointFieldValue(point, 'car_size_p90', '2048i')
   })
 })
 

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -238,6 +238,7 @@ describe('evaluate', () => {
         status_code: 500,
         retrievalResult: 'ERROR_500',
         participantAddress: '0xcheater',
+        inet_group: 'abcd',
         // invalid task
         cid: 'bafyinvalid',
         provider_address: '/dns4/production-ipfs-peer.pinata.cloud/tcp/3000/ws/p2p/Qma8ddFEQWEU8ijWvdxXm3nxU7oHsRtCykAaVz8WUYhiKn',
@@ -271,6 +272,7 @@ describe('evaluate', () => {
     assertPointFieldValue(point, 'unique_tasks', '1i')
     assertPointFieldValue(point, 'success_rate', '1')
     assertPointFieldValue(point, 'participants', '1')
+    assertPointFieldValue(point, 'inet_groups', '1')
 
     point = telemetry.find(p => p.name === 'retrieval_stats_all')
     assert(!!point,
@@ -278,6 +280,7 @@ describe('evaluate', () => {
     assertPointFieldValue(point, 'unique_tasks', '2i')
     assertPointFieldValue(point, 'success_rate', '0.5')
     assertPointFieldValue(point, 'participants', '2')
+    assertPointFieldValue(point, 'inet_groups', '2')
   })
 })
 

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -87,9 +87,9 @@ describe('evaluate', () => {
       `No telemetry point "evaluate" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
     // TODO: assert point fields
 
-    point = telemetry.find(p => p.name === 'retrieval_stats')
+    point = telemetry.find(p => p.name === 'retrieval_stats_honest')
     assert(!!point,
-      `No telemetry point "retrieval_stats" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
+      `No telemetry point "retrieval_stats_honest" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
     assertPointFieldValue(point, 'unique_tasks', '1i')
     assertPointFieldValue(point, 'success_rate', '1')
   })
@@ -125,9 +125,9 @@ describe('evaluate', () => {
       `No telemetry point "evaluate" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
     // TODO: assert point fields
 
-    point = telemetry.find(p => p.name === 'retrieval_stats')
+    point = telemetry.find(p => p.name === 'retrieval_stats_honest')
     assert(!!point,
-          `No telemetry point "retrieval_stats" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
+          `No telemetry point "retrieval_stats_honest" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
     assertPointFieldValue(point, 'measurements', '0i')
     assertPointFieldValue(point, 'unique_tasks', '0i')
     // no more fields are set for empty rounds
@@ -282,9 +282,9 @@ describe('evaluate', () => {
       logger
     })
 
-    let point = telemetry.find(p => p.name === 'retrieval_stats')
+    let point = telemetry.find(p => p.name === 'retrieval_stats_honest')
     assert(!!point,
-      `No telemetry point "retrieval_stats" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
+      `No telemetry point "retrieval_stats_honest" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
     debug(point.name, point.fields)
 
     assertPointFieldValue(point, 'unique_tasks', '1i')

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -275,6 +275,9 @@ describe('evaluate', () => {
     assertPointFieldValue(point, 'inet_groups', '1i')
     assertPointFieldValue(point, 'measurements', '1i')
 
+    assertPointFieldValue(point, 'result_rate_OK', '1')
+    assertPointFieldValue(point, 'result_rate_TIMEOUT', '0')
+
     point = telemetry.find(p => p.name === 'retrieval_stats_all')
     assert(!!point,
       `No telemetry point "retrieval_stats_all" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
@@ -283,6 +286,10 @@ describe('evaluate', () => {
     assertPointFieldValue(point, 'participants', '2i')
     assertPointFieldValue(point, 'inet_groups', '2i')
     assertPointFieldValue(point, 'measurements', '2i')
+
+    assertPointFieldValue(point, 'result_rate_OK', '0.5')
+    assertPointFieldValue(point, 'result_rate_TIMEOUT', '0')
+    assertPointFieldValue(point, 'result_rate_ERROR_500', '0.5')
   })
 })
 

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -271,16 +271,18 @@ describe('evaluate', () => {
       `No telemetry point "retrieval_stats" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
     assertPointFieldValue(point, 'unique_tasks', '1i')
     assertPointFieldValue(point, 'success_rate', '1')
-    assertPointFieldValue(point, 'participants', '1')
-    assertPointFieldValue(point, 'inet_groups', '1')
+    assertPointFieldValue(point, 'participants', '1i')
+    assertPointFieldValue(point, 'inet_groups', '1i')
+    assertPointFieldValue(point, 'measurements', '1i')
 
     point = telemetry.find(p => p.name === 'retrieval_stats_all')
     assert(!!point,
       `No telemetry point "retrieval_stats_all" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
     assertPointFieldValue(point, 'unique_tasks', '2i')
     assertPointFieldValue(point, 'success_rate', '0.5')
-    assertPointFieldValue(point, 'participants', '2')
-    assertPointFieldValue(point, 'inet_groups', '2')
+    assertPointFieldValue(point, 'participants', '2i')
+    assertPointFieldValue(point, 'inet_groups', '2i')
+    assertPointFieldValue(point, 'measurements', '2i')
   })
 })
 

--- a/test/helpers/assertions.js
+++ b/test/helpers/assertions.js
@@ -1,0 +1,10 @@
+import assert from 'node:assert'
+
+export const assertPointFieldValue = (point, fieldName, expectedValue) => {
+  const actualValue = point.fields[fieldName]
+  assert.strictEqual(
+    actualValue,
+    expectedValue,
+   `Expected ${point.name}.fields.${fieldName} to equal ${expectedValue} but found ${actualValue}`
+  )
+}

--- a/test/helpers/test-data.js
+++ b/test/helpers/test-data.js
@@ -1,0 +1,32 @@
+export const VALID_PARTICIPANT_ADDRESS = '0x000000000000000000000000000000000000dEaD'
+
+export const VALID_TASK = {
+  cid: 'QmUuEoBdjC8D1PfWZCc7JCSK8nj7TV6HbXWDHYHzZHCVGS',
+  providerAddress: '/dns4/production-ipfs-peer.pinata.cloud/tcp/3000/ws/p2p/Qma8ddFEQWEU8ijWvdxXm3nxU7oHsRtCykAaVz8WUYhiKn',
+  protocol: 'bitswap'
+}
+Object.freeze(VALID_TASK)
+
+/** @type {import('../lib/typings').Measurement} */
+export const VALID_MEASUREMENT = {
+  cid: VALID_TASK.cid,
+  provider_address: VALID_TASK.providerAddress,
+  protocol: VALID_TASK.protocol,
+  participantAddress: VALID_PARTICIPANT_ADDRESS,
+  inet_group: 'some-group-id',
+  status_code: 200,
+  timeout: false,
+  car_too_large: false,
+  start_at: '2023-11-01T09:00:00.000Z',
+  first_byte_at: '2023-11-01T09:00:01.000Z',
+  end_at: '2023-11-01T09:00:02.000Z',
+  finished_at: '2023-11-01T09:00:10.000Z',
+  byte_length: 1024,
+  retrievalResult: 'OK'
+}
+
+// Fraud detection is mutating the measurements parsed from JSON
+// To prevent tests from accidentally mutating data used by subsequent tests,
+// we freeze this test data object. If we forget to clone this default measurement
+// then such test will immediately fail.
+Object.freeze(VALID_MEASUREMENT)

--- a/test/preprocess.js
+++ b/test/preprocess.js
@@ -152,7 +152,7 @@ describe('calculateRetrievalResult', () => {
       ...SUCCESSFUL_RETRIEVAL,
       status_code: 500
     })
-    assert.strictEqual(result, 'SERVER_ERROR')
+    assert.strictEqual(result, 'ERROR_500')
   })
 
   it('SERVER_ERROR - 503', () => {
@@ -160,7 +160,7 @@ describe('calculateRetrievalResult', () => {
       ...SUCCESSFUL_RETRIEVAL,
       status_code: 503
     })
-    assert.strictEqual(result, 'SERVER_ERROR')
+    assert.strictEqual(result, 'ERROR_503')
   })
 
   it('UNKNOWN_ERROR - missing end_at', () => {

--- a/test/preprocess.js
+++ b/test/preprocess.js
@@ -1,4 +1,4 @@
-import { calculateRetrievalResult, parseParticipantAddress, preprocess } from '../lib/preprocess.js'
+import { getRetrievalResult, parseParticipantAddress, preprocess } from '../lib/preprocess.js'
 import assert from 'node:assert'
 import createDebug from 'debug'
 
@@ -87,7 +87,7 @@ describe('preprocess', () => {
   })
 })
 
-describe('calculateRetrievalResult', () => {
+describe('getRetrievalResult', () => {
   /** @type {import('../lib/typings').Measurement} */
   const SUCCESSFUL_RETRIEVAL = {
     id: 11009569,
@@ -109,14 +109,14 @@ describe('calculateRetrievalResult', () => {
   }
 
   it('successful retrieval', () => {
-    const result = calculateRetrievalResult({
+    const result = getRetrievalResult({
       ...SUCCESSFUL_RETRIEVAL
     })
     assert.strictEqual(result, 'OK')
   })
 
   it('TIMEOUT', () => {
-    const result = calculateRetrievalResult({
+    const result = getRetrievalResult({
       ...SUCCESSFUL_RETRIEVAL,
       timeout: true
     })
@@ -124,7 +124,7 @@ describe('calculateRetrievalResult', () => {
   })
 
   it('CAR_TOO_LARGE', () => {
-    const result = calculateRetrievalResult({
+    const result = getRetrievalResult({
       ...SUCCESSFUL_RETRIEVAL,
       car_too_large: true
     })
@@ -132,7 +132,7 @@ describe('calculateRetrievalResult', () => {
   })
 
   it('BAD_GATEWAY', () => {
-    const result = calculateRetrievalResult({
+    const result = getRetrievalResult({
       ...SUCCESSFUL_RETRIEVAL,
       status_code: 502
     })
@@ -140,7 +140,7 @@ describe('calculateRetrievalResult', () => {
   })
 
   it('GATEWAY_TIMEOUT', () => {
-    const result = calculateRetrievalResult({
+    const result = getRetrievalResult({
       ...SUCCESSFUL_RETRIEVAL,
       status_code: 504
     })
@@ -148,7 +148,7 @@ describe('calculateRetrievalResult', () => {
   })
 
   it('SERVER_ERROR - 500', () => {
-    const result = calculateRetrievalResult({
+    const result = getRetrievalResult({
       ...SUCCESSFUL_RETRIEVAL,
       status_code: 500
     })
@@ -156,7 +156,7 @@ describe('calculateRetrievalResult', () => {
   })
 
   it('SERVER_ERROR - 503', () => {
-    const result = calculateRetrievalResult({
+    const result = getRetrievalResult({
       ...SUCCESSFUL_RETRIEVAL,
       status_code: 503
     })
@@ -164,7 +164,7 @@ describe('calculateRetrievalResult', () => {
   })
 
   it('UNKNOWN_ERROR - missing end_at', () => {
-    const result = calculateRetrievalResult({
+    const result = getRetrievalResult({
       ...SUCCESSFUL_RETRIEVAL,
       end_at: undefined
     })

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -1,0 +1,62 @@
+import createDebug from 'debug'
+import { Point } from '../lib/telemetry.js'
+import { buildRetrievalStats } from '../lib/retrieval-stats.js'
+import { VALID_MEASUREMENT } from './helpers/test-data.js'
+import { assertPointFieldValue } from './helpers/assertions.js'
+
+const debug = createDebug('test')
+
+describe('retrieval statistics', () => {
+  it('reports all stats', async () => {
+    const measurements = [
+      {
+        ...VALID_MEASUREMENT
+      },
+      {
+        ...VALID_MEASUREMENT,
+        status_code: 500,
+        retrievalResult: 'ERROR_500',
+        participantAddress: '0xcheater',
+        inet_group: 'abcd',
+        start_at: '2023-11-01T09:00:00.000Z',
+        first_byte_at: '2023-11-01T09:00:10.000Z',
+        end_at: '2023-11-01T09:00:20.000Z',
+        finished_at: '2023-11-01T09:00:30.000Z',
+        byte_length: 2048,
+
+        // invalid task
+        cid: 'bafyinvalid',
+        provider_address: '/dns4/production-ipfs-peer.pinata.cloud/tcp/3000/ws/p2p/Qma8ddFEQWEU8ijWvdxXm3nxU7oHsRtCykAaVz8WUYhiKn',
+        protocol: 'bitswap'
+      }
+    ]
+
+    const point = new Point('retrieval_stats_all')
+    buildRetrievalStats(measurements, point)
+    debug('stats', point.fields)
+
+    assertPointFieldValue(point, 'measurements', '2i')
+    assertPointFieldValue(point, 'unique_tasks', '2i')
+    assertPointFieldValue(point, 'success_rate', '0.5')
+    assertPointFieldValue(point, 'participants', '2i')
+    assertPointFieldValue(point, 'inet_groups', '2i')
+    assertPointFieldValue(point, 'measurements', '2i')
+    assertPointFieldValue(point, 'download_bandwidth', '3072i')
+
+    assertPointFieldValue(point, 'result_rate_OK', '0.5')
+    assertPointFieldValue(point, 'result_rate_TIMEOUT', '0')
+    assertPointFieldValue(point, 'result_rate_ERROR_500', '0.5')
+
+    assertPointFieldValue(point, 'ttfb_min', '1000i')
+    assertPointFieldValue(point, 'ttfb_mean', '5500i')
+    assertPointFieldValue(point, 'ttfb_p90', '10000i')
+
+    assertPointFieldValue(point, 'duration_p10', '2000i')
+    assertPointFieldValue(point, 'duration_mean', '11000i')
+    assertPointFieldValue(point, 'duration_p90', '20000i')
+
+    assertPointFieldValue(point, 'car_size_p10', '1024i')
+    assertPointFieldValue(point, 'car_size_mean', '1536i')
+    assertPointFieldValue(point, 'car_size_p90', '2048i')
+  })
+})


### PR DESCRIPTION
To rework our Grafana dashboards to source metrics from InfluxDB instead of Postgres, I am implementing a new telemetry point that will be submitted for each evaluated round.

Point names:
- `retrieval_stats_honest` - only measurements assessed as honest
- `retrieval_stats_all` - all measurements, including those potentially fraudulent

Fields:
- `round_index`
- `unique_tasks` - how many unique CIDs we tested
- `success_rate` - how many retrievals ended up with success
- `result_rate_{result}` - breakdown of different retrieval results, e.g. `result_rate_OK`
- `inet_groups` - number of unique IPv4 /24 subnets
- `measurements` - number of measurements
- `download_bandwidth`
- `participants`
- Histograms - the following values are reported for all fields: `min`, `mean`, `max`, `p10`, `p50`, `p90`, `p95`
  - `ttfb`, e.g. `ttfb_p90`
  - `duration`, e.g. `duration_min`
  - `car_size`, e.g. `car_size_max`


Links:
- https://github.com/filecoin-station/spark-api/issues/144