### PR TITLE
fix: re-enable `group_winning_{min,max,mean}`

### DIFF
--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/node'
 import createDebug from 'debug'
 import assert from 'node:assert'
 import * as Sentry from '@sentry/node'

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/node'
 import createDebug from 'debug'
 import assert from 'node:assert'
 
@@ -117,10 +118,17 @@ export const evaluate = async ({
       point.intField(`measurements_${type}`, count)
     }
 
-    // FIXME @bajtos
-    // for (const [key, value] of Object.entries(fraudDetectionStats.groupWinning)) {
-    //   point.floatField(`group_winning_${key}`, value)
-    // }
+    for (const [key, value] of Object.entries(fraudDetectionStats.groupWinning)) {
+      // At some point, we had a bug in the evaluation pipeline which caused some group winning
+      // rates to be undefined or NaN. InfluxDB client rejected such values, which triggered
+      // unhandled error. Let's avoid that situation by ignoring such data points.
+      try {
+        point.floatField(`group_winning_${key}`, value)
+      } catch (err) {
+        console.error(err)
+        Sentry.captureException(err, { extra: { roundIndex } })
+      }
+    }
   })
 }
 
@@ -233,10 +241,17 @@ export const runFraudDetection = async (roundIndex, measurements, sparkRoundDeta
  * @returns {import('./typings').GroupWinningStats}
  */
 const calculateInetGroupSuccessRates = (taskGroups) => {
+  debug('calculateInetGroupSuccessRates')
+
   /** @type {Map<string, {won: number, lost: number}> */
   const participantStats = new Map()
 
   for (const groupMeasurements of taskGroups.values()) {
+    debug(
+      '  measurements for inet_group=%s cid=%s',
+      groupMeasurements[0].inet_group,
+      groupMeasurements[0].cid
+    )
     // First, find participants that submitted some valid measurements for this task
     // and find out whether they were rewarded or not
 
@@ -245,9 +260,13 @@ const calculateInetGroupSuccessRates = (taskGroups) => {
     for (const m of groupMeasurements) {
       if (m.fraudAssessment === 'OK') {
         taskParticipants.set(m.participantAddress, true)
+        debug('    %s -> won', m.participantAddress)
       } else if (m.fraudAssessment === 'DUP_INET_GROUP') {
         if (!taskParticipants.has(m.participantAddress)) {
           taskParticipants.set(m.participantAddress, false)
+          debug('    %s -> lost', m.participantAddress)
+        } else {
+          debug('    %s -> skip (redundant)', m.participantAddress)
         }
       }
     }
@@ -264,6 +283,11 @@ const calculateInetGroupSuccessRates = (taskGroups) => {
     }
   }
 
+  if (!participantStats.size) {
+    console.log('This round has no participants with OK or DUP_INET_GROUP measurements.')
+    return { min: 1, mean: 1, max: 1 }
+  }
+
   // Finally, calculate the aggregate statistics
   const result = { min: 1.0, max: 0.0, mean: undefined }
   let sum = 0
@@ -276,6 +300,7 @@ const calculateInetGroupSuccessRates = (taskGroups) => {
   }
   result.mean = sum / participantStats.size
 
+  debug('Winning rates stats: %o', result)
   return result
 }
 

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -87,18 +87,10 @@ describe('evaluate', () => {
     let point = telemetry.find(p => p.name === 'evaluate')
     assert(!!point,
       `No telemetry point "evaluate" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
-    assert.strictEqual(point.fields.unique_tasks, '0i')
-    assert.strictEqual(point.fields.measurements, '0i')
-    // no more fields are set for empty rounds
-    assert.deepStrictEqual(Object.keys(point.fields), [
-      'round_index',
-      'measurements',
-      'unique_tasks'
-    ])
 
-    assert.strictEqual(point.fields.group_winning_min, '1')
-    assert.strictEqual(point.fields.group_winning_mean, '1')
-    assert.strictEqual(point.fields.group_winning_max, '1')
+    assertPointFieldValue(point, 'group_winning_min', '1')
+    assertPointFieldValue(point, 'group_winning_mean', '1')
+    assertPointFieldValue(point, 'group_winning_max', '1')
     // TODO: assert point fields
 
     point = telemetry.find(p => p.name === 'retrieval_stats_honest')
@@ -106,6 +98,12 @@ describe('evaluate', () => {
           `No telemetry point "retrieval_stats_honest" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
     assertPointFieldValue(point, 'measurements', '0i')
     assertPointFieldValue(point, 'unique_tasks', '0i')
+    // no more fields are set for empty rounds
+    assert.deepStrictEqual(Object.keys(point.fields), [
+      'round_index',
+      'measurements',
+      'unique_tasks'
+    ])
   })
   it('handles unknown rounds', async () => {
     const rounds = {}
@@ -179,10 +177,9 @@ describe('evaluate', () => {
     const point = telemetry.find(p => p.name === 'evaluate')
     assert(!!point,
       `No telemetry point "evaluate" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
-    assert.strictEqual(point.fields.unique_tasks, '1i')
-    assert.strictEqual(point.fields.group_winning_min, '1')
-    assert.strictEqual(point.fields.group_winning_mean, '1')
-    assert.strictEqual(point.fields.group_winning_max, '1')
+    assertPointFieldValue(point, 'group_winning_min', '1')
+    assertPointFieldValue(point, 'group_winning_mean', '1')
+    assertPointFieldValue(point, 'group_winning_max', '1')
   })
 
   it('adds a dummy entry to ensure scores add up exactly to MAX_SCORE', async () => {

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -108,6 +108,10 @@ describe('evaluate', () => {
     assert(!!point,
       `No telemetry point "evaluate" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
     assert.strictEqual(point.fields.unique_tasks, '0i')
+
+    assert.strictEqual(point.fields.group_winning_min, '1')
+    assert.strictEqual(point.fields.group_winning_mean, '1')
+    assert.strictEqual(point.fields.group_winning_max, '1')
   })
   it('handles unknown rounds', async () => {
     const rounds = {}
@@ -177,6 +181,14 @@ describe('evaluate', () => {
       `Sum of scores not close enough. Got ${sum}`
     )
     assert.strictEqual(setScoresCalls[0].scores.length, 2)
+
+    const point = telemetry.find(p => p.name === 'evaluate')
+    assert(!!point,
+      `No telemetry point "evaluate" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
+    assert.strictEqual(point.fields.unique_tasks, '1i')
+    assert.strictEqual(point.fields.group_winning_min, '1')
+    assert.strictEqual(point.fields.group_winning_mean, '1')
+    assert.strictEqual(point.fields.group_winning_max, '1')
   })
 
   it('adds a dummy entry to ensure scores add up exactly to MAX_SCORE', async () => {


### PR DESCRIPTION
See https://github.com/filecoin-station/spark-evaluate/commit/ddfe10abd91eb440f1e5f0608b6778a737f15b81