### PR TITLE
fix: retrieval stats - ttfb & duration

### DIFF
--- a/lib/retrieval-stats.js
+++ b/lib/retrieval-stats.js
@@ -73,8 +73,8 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
       downloadBandwidth += byteLength
       sizeHistogram.recordValue(byteLength)
     }
-    if (ttfb !== undefined) ttfbHistogram.recordValue(ttfb)
-    if (duration !== undefined) durationHistogram.recordValue(duration)
+    if (ttfb !== undefined && ttfb > 0 && m.status_code === 200) ttfbHistogram.recordValue(ttfb)
+    if (duration !== undefined && duration > 0) durationHistogram.recordValue(duration)
   }
   const successRate = resultBreakdown.OK / totalCount
 
@@ -113,6 +113,7 @@ const parseDateTime = (str) => {
  * @param {hdr.Histogram} histogram
  */
 const addHistogramToPoint = (point, fieldNamePrefix, histogram) => {
+  if (histogram.totalCount < 1) return
   point.intField(`${fieldNamePrefix}_min`, histogram.minNonZeroValue)
   point.intField(`${fieldNamePrefix}_mean`, histogram.mean)
   point.intField(`${fieldNamePrefix}_max`, histogram.maxValue)

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -14,6 +14,23 @@ describe('retrieval statistics', () => {
       },
       {
         ...VALID_MEASUREMENT,
+        timeout: true,
+        retrievalResult: 'TIMEOUT',
+
+        start_at: '2023-11-01T09:00:00.000Z',
+        first_byte_at: '2023-11-01T09:00:10.000Z',
+        end_at: '2023-11-01T09:00:50.000Z',
+        finished_at: '2023-11-01T09:00:30.000Z',
+        byte_length: 2048
+      },
+      {
+        ...VALID_MEASUREMENT,
+        carTooLarge: true,
+        retrievalResult: 'CAR_TOO_LARGE',
+        byte_length: 200 * 1024 * 1024
+      },
+      {
+        ...VALID_MEASUREMENT,
         status_code: 500,
         retrievalResult: 'ERROR_500',
         participantAddress: '0xcheater',
@@ -31,32 +48,64 @@ describe('retrieval statistics', () => {
       }
     ]
 
-    const point = new Point('retrieval_stats_all')
+    const point = new Point('stats')
     buildRetrievalStats(measurements, point)
     debug('stats', point.fields)
 
-    assertPointFieldValue(point, 'measurements', '2i')
+    assertPointFieldValue(point, 'measurements', '4i')
     assertPointFieldValue(point, 'unique_tasks', '2i')
-    assertPointFieldValue(point, 'success_rate', '0.5')
+    assertPointFieldValue(point, 'success_rate', '0.25')
     assertPointFieldValue(point, 'participants', '2i')
     assertPointFieldValue(point, 'inet_groups', '2i')
-    assertPointFieldValue(point, 'measurements', '2i')
-    assertPointFieldValue(point, 'download_bandwidth', '3072i')
+    assertPointFieldValue(point, 'download_bandwidth', '209720320i')
 
-    assertPointFieldValue(point, 'result_rate_OK', '0.5')
-    assertPointFieldValue(point, 'result_rate_TIMEOUT', '0')
-    assertPointFieldValue(point, 'result_rate_ERROR_500', '0.5')
+    assertPointFieldValue(point, 'result_rate_OK', '0.25')
+    assertPointFieldValue(point, 'result_rate_TIMEOUT', '0.25')
+    assertPointFieldValue(point, 'result_rate_CAR_TOO_LARGE', '0.25')
+    assertPointFieldValue(point, 'result_rate_ERROR_500', '0.25')
 
     assertPointFieldValue(point, 'ttfb_min', '1000i')
-    assertPointFieldValue(point, 'ttfb_mean', '5500i')
+    assertPointFieldValue(point, 'ttfb_mean', '4000i')
     assertPointFieldValue(point, 'ttfb_p90', '10000i')
 
     assertPointFieldValue(point, 'duration_p10', '2000i')
-    assertPointFieldValue(point, 'duration_mean', '11000i')
-    assertPointFieldValue(point, 'duration_p90', '20000i')
+    assertPointFieldValue(point, 'duration_mean', '18500i')
+    assertPointFieldValue(point, 'duration_p90', '50000i')
 
     assertPointFieldValue(point, 'car_size_p10', '1024i')
-    assertPointFieldValue(point, 'car_size_mean', '1536i')
-    assertPointFieldValue(point, 'car_size_p90', '2048i')
+    assertPointFieldValue(point, 'car_size_mean', '52430208i')
+    assertPointFieldValue(point, 'car_size_p90', '209716223i')
+  })
+
+  it('handles first_byte_at set to unix epoch', () => {
+    const measurements = [
+      {
+        ...VALID_MEASUREMENT,
+        start_at: '2023-11-01T09:00:00.000Z',
+        first_byte_at: '1970-01-01T00:00:00.000Z'
+      }
+    ]
+    const point = new Point('stats')
+    buildRetrievalStats(measurements, point)
+    debug('stats', point.fields)
+    assertPointFieldValue(point, 'ttfb_min', undefined)
+    assertPointFieldValue(point, 'ttfb_mean', undefined)
+    assertPointFieldValue(point, 'ttfb_p90', undefined)
+  })
+
+  it('handles end_at set to unix epoch', () => {
+    const measurements = [
+      {
+        ...VALID_MEASUREMENT,
+        start_at: '2023-11-01T09:00:00.000Z',
+        end_at: '1970-01-01T00:00:00.000Z'
+      }
+    ]
+    const point = new Point('stats')
+    buildRetrievalStats(measurements, point)
+    debug('stats', point.fields)
+    assertPointFieldValue(point, 'duration_p10', undefined)
+    assertPointFieldValue(point, 'duration_mean', undefined)
+    assertPointFieldValue(point, 'duration_p90', undefined)
   })
 })


### PR DESCRIPTION
When the retrieval fails, `end_at` and `first_byte_at` are set to unix epoch (1970-01-01T00:00:00.000Z). We need to ignore such measurements when calculating ttfb & duration stats.

Links:
- https://github.com/filecoin-station/spark-api/issues/144
- https://github.com/filecoin-station/spark-evaluate/pull/67