### PR TITLE
fix: measurements with status_code set to null

### DIFF
--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -59,6 +59,10 @@ export const preprocess = async ({
     { total: measurements.length, valid: validMeasurements.length }
   )
 
+  const ok = validMeasurements.reduce((c, m) => m.retrievalResult === 'OK' ? c + 1 : c, 0)
+  const total = validMeasurements.length
+  logger.log('Retrieval Success Rate: %s%s (%s of %s)', Math.round(100 * ok / total), '%', ok, total)
+
   if (!rounds[roundIndex]) {
     rounds[roundIndex] = []
   }
@@ -87,6 +91,8 @@ export const preprocess = async ({
     }
     point.intField('total', total)
   })
+
+  return validMeasurements
 }
 
 export const fetchMeasurementsViaClient = async (web3Storage, cid) => {
@@ -150,7 +156,7 @@ export const getRetrievalResult = measurement => {
   }
   if (measurement.status_code >= 300) return `ERROR_${measurement.status_code}`
 
-  const ok = typeof measurement.end_at === 'string'
+  const ok = measurement.status_code >= 200 && typeof measurement.end_at === 'string'
 
   return ok ? 'OK' : 'UNKNOWN_ERROR'
 }

--- a/lib/typings.d.ts
+++ b/lib/typings.d.ts
@@ -59,7 +59,7 @@ export interface Measurement {
   end_at: string;
   finished_at: string;
 
-  status_code: number;
+  status_code: number | undefined | null;
   timeout: boolean;
   byte_length: number;
   car_too_large: boolean;

--- a/test/preprocess.js
+++ b/test/preprocess.js
@@ -183,4 +183,13 @@ describe('getRetrievalResult', () => {
     })
     assert.strictEqual(result, 'UNKNOWN_ERROR')
   })
+
+  it('UNKNOWN_ERROR - status_code is null', () => {
+    const result = getRetrievalResult({
+      ...SUCCESSFUL_RETRIEVAL,
+      timeout: false,
+      status_code: null
+    })
+    assert.strictEqual(result, 'UNKNOWN_ERROR')
+  })
 })


### PR DESCRIPTION
Fix `getRetrievalResult()` to correctly handle measurements where `status_code` is not 2xx.

Links:
- https://github.com/filecoin-station/spark-api/issues/144
- https://github.com/filecoin-station/spark-evaluate/pull/67
