### PR TITLE
perf: cache string values

### DIFF
--- a/bin/dry-run.js
+++ b/bin/dry-run.js
@@ -79,7 +79,7 @@ for (const cid of measurementCids) {
   })
 }
 
-console.log('Fetched %s measurements', rounds[roundIndex].length)
+console.log('Fetched %s measurements', rounds[roundIndex].measurements.length)
 
 console.log('==EVALUATE==')
 const ieContractWithSigner = {

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -26,7 +26,7 @@ export const evaluate = async ({
 }) => {
   // Get measurements
   /** @type {Record<string, any>[]} */
-  const measurements = rounds[roundIndex] || []
+  const measurements = rounds[roundIndex]?.measurements || []
 
   // Detect fraud
 

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -9,16 +9,16 @@ import createDebug from 'debug'
 const debug = createDebug('spark:preprocess')
 
 export class Measurement {
-  constructor (m) {
-    this.participantAddress = parseParticipantAddress(m.participant_address)
-    this.retrievalResult = getRetrievalResult(m)
-    this.cid = m.cid
-    this.spark_version = m.spark_version
+  constructor (m, pointerize = (v) => v) {
+    this.participantAddress = pointerize(parseParticipantAddress(m.participant_address))
+    this.retrievalResult = pointerize(getRetrievalResult(m))
+    this.cid = pointerize(m.cid)
+    this.spark_version = pointerize(m.spark_version)
     this.fraudAssessment = null
-    this.inet_group = m.inet_group
+    this.inet_group = pointerize(m.inet_group)
     this.finished_at = m.finished_at
     this.provider_address = m.provider_address
-    this.protocol = m.protocol
+    this.protocol = pointerize(m.protocol)
     this.byte_length = m.byte_length
     this.start_at = m.start_at
     this.first_byte_at = m.first_byte_at
@@ -34,6 +34,21 @@ export const preprocess = async ({
   recordTelemetry,
   logger
 }) => {
+  if (!rounds[roundIndex]) {
+    rounds[roundIndex] = []
+    rounds[roundIndex]._strings = new Map()
+  }
+
+  const knownStrings = rounds[roundIndex]._strings
+  assert(knownStrings)
+  const pointerize = (str) => {
+    if (str === undefined || str === null) return str
+    const found = knownStrings.get(str)
+    if (found) return found
+    knownStrings.set(str, str)
+    return str
+  }
+
   const start = new Date()
   /** @type import('./typings').Measurement[] */
   const measurements = await fetchMeasurements(cid)
@@ -42,7 +57,7 @@ export const preprocess = async ({
     // eslint-disable-next-line camelcase
     .map(measurement => {
       try {
-        return new Measurement(measurement)
+        return new Measurement(measurement, pointerize)
       } catch (err) {
         logger.error('Invalid measurement:', err.message, measurement)
         return null
@@ -80,9 +95,6 @@ export const preprocess = async ({
   const total = validMeasurements.length
   logger.log('Retrieval Success Rate: %s%s (%s of %s)', Math.round(100 * okCount / total), '%', okCount, total)
 
-  if (!rounds[roundIndex]) {
-    rounds[roundIndex] = []
-  }
   rounds[roundIndex].push(...validMeasurements)
 
   recordTelemetry('preprocess', point => {

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -5,6 +5,7 @@ import { CarReader } from '@ipld/car'
 import { validateBlock } from '@web3-storage/car-block-validator'
 import { recursive as exporter } from 'ipfs-unixfs-exporter'
 import createDebug from 'debug'
+import { RoundData } from './round.js'
 
 const debug = createDebug('spark:preprocess')
 
@@ -35,18 +36,7 @@ export const preprocess = async ({
   logger
 }) => {
   if (!rounds[roundIndex]) {
-    rounds[roundIndex] = []
-    rounds[roundIndex]._strings = new Map()
-  }
-
-  const knownStrings = rounds[roundIndex]._strings
-  assert(knownStrings)
-  const pointerize = (str) => {
-    if (str === undefined || str === null) return str
-    const found = knownStrings.get(str)
-    if (found) return found
-    knownStrings.set(str, str)
-    return str
+    rounds[roundIndex] = new RoundData()
   }
 
   const start = new Date()
@@ -57,7 +47,7 @@ export const preprocess = async ({
     // eslint-disable-next-line camelcase
     .map(measurement => {
       try {
-        return new Measurement(measurement, pointerize)
+        return new Measurement(measurement, rounds[roundIndex].pointerize)
       } catch (err) {
         logger.error('Invalid measurement:', err.message, measurement)
         return null
@@ -95,7 +85,7 @@ export const preprocess = async ({
   const total = validMeasurements.length
   logger.log('Retrieval Success Rate: %s%s (%s of %s)', Math.round(100 * okCount / total), '%', okCount, total)
 
-  rounds[roundIndex].push(...validMeasurements)
+  rounds[roundIndex].measurements.push(...validMeasurements)
 
   recordTelemetry('preprocess', point => {
     point.intField('round_index', roundIndex)

--- a/lib/round.js
+++ b/lib/round.js
@@ -1,0 +1,20 @@
+export class RoundData {
+  /** @type {Map<string, string>} */
+  #knownStrings
+
+  constructor () {
+    /** @type {import('./preprocess').Measurement[]} */
+    this.measurements = []
+    this.#knownStrings = new Map()
+
+    // defined as a rocket function that can be detached
+    // from this object and passed around as a lambda fn
+    this.pointerize = (str) => {
+      if (str === undefined || str === null) return str
+      const found = this.#knownStrings.get(str)
+      if (found !== undefined) return found
+      this.#knownStrings.set(str, str)
+      return str
+    }
+  }
+}

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -5,6 +5,7 @@ import { ethers } from 'ethers'
 import createDebug from 'debug'
 import { VALID_MEASUREMENT, VALID_TASK } from './helpers/test-data.js'
 import { assertPointFieldValue } from './helpers/assertions.js'
+import { RoundData } from '../lib/round.js'
 
 const { BigNumber } = ethers
 
@@ -22,9 +23,9 @@ beforeEach(() => telemetry.splice(0))
 
 describe('evaluate', () => {
   it('evaluates measurements', async () => {
-    const rounds = { 0: [] }
+    const rounds = { 0: new RoundData() }
     for (let i = 0; i < 10; i++) {
-      rounds[0].push({ ...VALID_MEASUREMENT })
+      rounds[0].measurements.push({ ...VALID_MEASUREMENT })
     }
     const fetchRoundDetails = () => ({ retrievalTasks: [VALID_TASK] })
     const setScoresCalls = []
@@ -58,7 +59,7 @@ describe('evaluate', () => {
     // TODO: assert point fields
   })
   it('handles empty rounds', async () => {
-    const rounds = { 0: [] }
+    const rounds = { 0: new RoundData() }
     const setScoresCalls = []
     const ieContractWithSigner = {
       async setScores (roundIndex, participantAddresses, scores) {
@@ -133,11 +134,11 @@ describe('evaluate', () => {
     ])
   })
   it('calculates reward shares', async () => {
-    const rounds = { 0: [] }
+    const rounds = { 0: new RoundData() }
     for (let i = 0; i < 5; i++) {
-      rounds[0].push({ ...VALID_MEASUREMENT, participantAddress: '0x123' })
-      rounds[0].push({ ...VALID_MEASUREMENT, participantAddress: '0x234', inet_group: 'group2' })
-      rounds[0].push({
+      rounds[0].measurements.push({ ...VALID_MEASUREMENT, participantAddress: '0x123' })
+      rounds[0].measurements.push({ ...VALID_MEASUREMENT, participantAddress: '0x234', inet_group: 'group2' })
+      rounds[0].measurements.push({
         ...VALID_MEASUREMENT,
         inet_group: 'group3',
         // invalid task
@@ -183,10 +184,10 @@ describe('evaluate', () => {
   })
 
   it('adds a dummy entry to ensure scores add up exactly to MAX_SCORE', async () => {
-    const rounds = { 0: [] }
-    rounds[0].push({ ...VALID_MEASUREMENT, participantAddress: '0x123', inet_group: 'ig1' })
-    rounds[0].push({ ...VALID_MEASUREMENT, participantAddress: '0x234', inet_group: 'ig2' })
-    rounds[0].push({ ...VALID_MEASUREMENT, participantAddress: '0x456', inet_group: 'ig3' })
+    const rounds = { 0: new RoundData() }
+    rounds[0].measurements.push({ ...VALID_MEASUREMENT, participantAddress: '0x123', inet_group: 'ig1' })
+    rounds[0].measurements.push({ ...VALID_MEASUREMENT, participantAddress: '0x234', inet_group: 'ig2' })
+    rounds[0].measurements.push({ ...VALID_MEASUREMENT, participantAddress: '0x456', inet_group: 'ig3' })
 
     const setScoresCalls = []
     const ieContractWithSigner = {
@@ -214,10 +215,10 @@ describe('evaluate', () => {
   })
 
   it('reports retrieval stats - honest & all', async () => {
-    const rounds = { 0: [] }
+    const rounds = { 0: new RoundData() }
     for (let i = 0; i < 5; i++) {
-      rounds[0].push({ ...VALID_MEASUREMENT })
-      rounds[0].push({
+      rounds[0].measurements.push({ ...VALID_MEASUREMENT })
+      rounds[0].measurements.push({
         ...VALID_MEASUREMENT,
         inet_group: 'group3',
         // invalid task

--- a/test/preprocess.js
+++ b/test/preprocess.js
@@ -33,6 +33,7 @@ describe('preprocess', () => {
     }
     const logger = { log: debug, error: console.error }
     await preprocess({ rounds, cid, roundIndex, fetchMeasurements, recordTelemetry, logger })
+    stripStringsLookupTable(rounds)
 
     assert.deepStrictEqual(rounds, {
       0: [new Measurement({
@@ -62,6 +63,8 @@ describe('preprocess', () => {
     const fetchMeasurements = async (_cid) => measurements
     const logger = { log: debug, error: debug }
     await preprocess({ rounds, cid, roundIndex, fetchMeasurements, recordTelemetry, logger })
+    stripStringsLookupTable(rounds)
+
     // We allow invalid participant address for now.
     // We should update this test when we remove this temporary workaround.
     assert.deepStrictEqual(rounds, {
@@ -99,6 +102,10 @@ describe('preprocess', () => {
     assert.strictEqual(converted, '0x3356fd7D01F001f5FdA3dc032e8bA14E54C2a1a1')
   })
 })
+
+const stripStringsLookupTable = (rounds) => {
+  for (const r of Object.values(rounds)) delete r._strings
+}
 
 describe('getRetrievalResult', () => {
   /** @type {import('../lib/typings').Measurement} */

--- a/test/preprocess.js
+++ b/test/preprocess.js
@@ -33,17 +33,17 @@ describe('preprocess', () => {
     }
     const logger = { log: debug, error: console.error }
     await preprocess({ rounds, cid, roundIndex, fetchMeasurements, recordTelemetry, logger })
-    stripStringsLookupTable(rounds)
 
-    assert.deepStrictEqual(rounds, {
-      0: [new Measurement({
+    assert.deepStrictEqual(Object.keys(rounds), ['0'])
+    assert.deepStrictEqual(rounds[0].measurements, [
+      new Measurement({
         participant_address: '0x999999cf1046e68e36E1aA2E0E07105eDDD1f08E',
         spark_version: '1.2.3',
         inet_group: 'ig1',
         finished_at: '2023-11-01T09:00.00.000Z',
         retrievalResult: 'UNKNOWN_ERROR'
-      })]
-    })
+      })
+    ])
     assert.deepStrictEqual(getCalls, [cid])
 
     const point = assertRecordedTelemetryPoint(telemetry, 'spark_versions')
@@ -63,18 +63,18 @@ describe('preprocess', () => {
     const fetchMeasurements = async (_cid) => measurements
     const logger = { log: debug, error: debug }
     await preprocess({ rounds, cid, roundIndex, fetchMeasurements, recordTelemetry, logger })
-    stripStringsLookupTable(rounds)
 
+    assert.deepStrictEqual(Object.keys(rounds), ['0'])
     // We allow invalid participant address for now.
     // We should update this test when we remove this temporary workaround.
-    assert.deepStrictEqual(rounds, {
-      0: [new Measurement({
+    assert.deepStrictEqual(rounds[0].measurements, [
+      new Measurement({
         participant_address: '0x000000000000000000000000000000000000dEaD',
         inet_group: 'ig1',
         finished_at: '2023-11-01T09:00.00.000Z',
         retrievalResult: 'UNKNOWN_ERROR'
-      })]
-    })
+      })
+    ])
   })
 
   it('converts mainnet wallet address to participant ETH address', () => {
@@ -102,10 +102,6 @@ describe('preprocess', () => {
     assert.strictEqual(converted, '0x3356fd7D01F001f5FdA3dc032e8bA14E54C2a1a1')
   })
 })
-
-const stripStringsLookupTable = (rounds) => {
-  for (const r of Object.values(rounds)) delete r._strings
-}
 
 describe('getRetrievalResult', () => {
   /** @type {import('../lib/typings').Measurement} */


### PR DESCRIPTION
For each round, keep a lookup table with all known string values.  When creating a new Measurement instance, replace incoming string values with the cached string instances.

This reduces memory usage by another ~70%.

**Before:**
```
{
  rss: 893943808,
  heapTotal: 570556416,
  heapUsed: 540473960,
  external: 5228292,
  arrayBuffers: 76335
}
```

**After:**
```
{
  rss: 561840128,
  heapTotal: 458522624,
  heapUsed: 407380752,
  external: 5660805,
  arrayBuffers: 559664
}
```

**After pointerizing provider_address:**
```
{
  rss: 3752099840,
  heapTotal: 167313408,
  heapUsed: 161246552,
  external: 3754973060,
  arrayBuffers: 35375
}
```