### PR TITLE
feat: rework histogram calculations

### DIFF
--- a/lib/retrieval-stats.js
+++ b/lib/retrieval-stats.js
@@ -1,14 +1,6 @@
 import createDebug from 'debug'
-import * as hdr from 'hdr-histogram-js'
 
 const debug = createDebug('spark:retrieval-stats')
-
-await hdr.initWebAssembly()
-const createHistogram = () => hdr.build({
-  numberOfSignificantValueDigits: 5,
-  bitBucketSize: 'packed',
-  useWebAssembly: true
-})
 
 /**
  * @param {import('./typings').Measurement[]} measurements
@@ -43,9 +35,9 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
   const inetGroups = new Set()
   let downloadBandwidth = 0
 
-  const ttfbHistogram = createHistogram()
-  const durationHistogram = createHistogram()
-  const sizeHistogram = createHistogram()
+  const ttfbValues = []
+  const durationValues = []
+  const sizeValues = []
 
   for (const m of measurements) {
     // `retrievalResult` should be always set by lib/preprocess.js, so we should never encounter
@@ -71,10 +63,10 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
     debug('size=%s ttfb=%s duration=%s valid? %s', byteLength, ttfb, duration, m.fraudAssessment === 'OK')
     if (byteLength !== undefined) {
       downloadBandwidth += byteLength
-      sizeHistogram.recordValue(byteLength)
+      sizeValues.push(byteLength)
     }
-    if (ttfb !== undefined && ttfb > 0 && m.status_code === 200) ttfbHistogram.recordValue(ttfb)
-    if (duration !== undefined && duration > 0) durationHistogram.recordValue(duration)
+    if (ttfb !== undefined && ttfb > 0 && m.status_code === 200) ttfbValues.push(ttfb)
+    if (duration !== undefined && duration > 0) durationValues.push(duration)
   }
   const successRate = resultBreakdown.OK / totalCount
 
@@ -85,14 +77,9 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
   telemetryPoint.intField('measurements', totalCount)
   telemetryPoint.intField('download_bandwidth', downloadBandwidth)
 
-  addHistogramToPoint(telemetryPoint, 'ttfb', ttfbHistogram)
-  ttfbHistogram.destroy()
-
-  addHistogramToPoint(telemetryPoint, 'duration', durationHistogram)
-  durationHistogram.destroy()
-
-  addHistogramToPoint(telemetryPoint, 'car_size', sizeHistogram)
-  sizeHistogram.destroy()
+  addHistogramToPoint(telemetryPoint, 'ttfb', ttfbValues)
+  addHistogramToPoint(telemetryPoint, 'duration', durationValues)
+  addHistogramToPoint(telemetryPoint, 'car_size', sizeValues)
 
   for (const [result, count] of Object.entries(resultBreakdown)) {
     telemetryPoint.floatField(`result_rate_${result}`, count / totalCount)
@@ -103,15 +90,18 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
  *
  * @param {import('./typings').Point} point
  * @param {string} fieldNamePrefix
- * @param {hdr.Histogram} histogram
+ * @param {number[]} values
  */
-const addHistogramToPoint = (point, fieldNamePrefix, histogram) => {
-  if (histogram.totalCount < 1) return
-  point.intField(`${fieldNamePrefix}_min`, histogram.minNonZeroValue)
-  point.intField(`${fieldNamePrefix}_mean`, histogram.mean)
-  point.intField(`${fieldNamePrefix}_max`, histogram.maxValue)
+const addHistogramToPoint = (point, fieldNamePrefix, values) => {
+  const count = values.length
+  if (count < 1) return
+  values.sort()
+  point.intField(`${fieldNamePrefix}_min`, values[0])
+  point.intField(`${fieldNamePrefix}_mean`, values.reduce((sum, v) => sum + v, 0) / count)
+  point.intField(`${fieldNamePrefix}_max`, values[count - 1])
   for (const p of [10, 50, 90, 95]) {
-    point.intField(`${fieldNamePrefix}_p${p}`, histogram.getValueAtPercentile(p))
+    const ix = Math.floor(p * count / 100)
+    point.intField(`${fieldNamePrefix}_p${p}`, values[ix])
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@web3-storage/car-block-validator": "^1.2.0",
     "debug": "^4.3.4",
     "ethers": "^5.7.2",
-    "hdr-histogram-js": "^3.0.0",
     "ipfs-car": "^1.0.0",
     "ipfs-unixfs-exporter": "^13.2.2"
   },

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -73,8 +73,8 @@ describe('retrieval statistics', () => {
     assertPointFieldValue(point, 'duration_p90', '50000i')
 
     assertPointFieldValue(point, 'car_size_p10', '1024i')
-    assertPointFieldValue(point, 'car_size_mean', '52430208i')
-    assertPointFieldValue(point, 'car_size_p90', '209716223i')
+    assertPointFieldValue(point, 'car_size_mean', '52430080i')
+    assertPointFieldValue(point, 'car_size_p90', '209715200i')
   })
 
   it('handles first_byte_at set to unix epoch', () => {


### PR DESCRIPTION
Remove the module `hdr-histogram-js` which was using a lot of external memory and producing only approximage values.

Rework the histogram calculation to collect all numbers into an array, sort the array and then pick items at p10/p50/p90 index.

Memory usage before - notice we were using ~3.5GB external memory:
```
{
  rss: 3526049792,
  heapTotal: 164167680,
  heapUsed: 159240088,
  external: 3754973060,
  arrayBuffers: 35375
}
```

Memory usage after - external is down to 3MB, heap total is up by 90MB:
```
{
  rss: 375226368,
  heapTotal: 259784704,
  heapUsed: 195350720,
  external: 4083229,
  arrayBuffers: 35016
}
```
