### PR TITLE
fix: calculating values at a given percentile

### DIFF
--- a/lib/retrieval-stats.js
+++ b/lib/retrieval-stats.js
@@ -104,7 +104,7 @@ const addHistogramToPoint = (point, fieldNamePrefix, values) => {
   }
 }
 
-const getValueAtPercentile = (values, p) => {
+export const getValueAtPercentile = (values, p) => {
   // See https://www.calculatorsoup.com/calculators/statistics/percentile-calculator.php
   // 1. Arrange n number of data points in ascending order: x1, x2, x3, ... xn
   const n = values.length

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -1,6 +1,7 @@
+import assert from 'node:assert'
 import createDebug from 'debug'
 import { Point } from '../lib/telemetry.js'
-import { buildRetrievalStats } from '../lib/retrieval-stats.js'
+import { buildRetrievalStats, getValueAtPercentile } from '../lib/retrieval-stats.js'
 import { VALID_MEASUREMENT } from './helpers/test-data.js'
 import { assertPointFieldValue } from './helpers/assertions.js'
 
@@ -107,5 +108,14 @@ describe('retrieval statistics', () => {
     assertPointFieldValue(point, 'duration_p10', undefined)
     assertPointFieldValue(point, 'duration_mean', undefined)
     assertPointFieldValue(point, 'duration_p90', undefined)
+  })
+})
+
+describe('getValueAtPercentile', () => {
+  it('interpolates the values', () => {
+    assert.strictEqual(
+      getValueAtPercentile([10, 20, 30], 90),
+      28
+    )
   })
 })


### PR DESCRIPTION
Rework the naive approach producing _discrete percentile_ to a different algorithm that produces _continuous percentile_.

Upside: we get more precise values.
Downside: the values are interpolated now.

Quoting from [Postgres docs](https://www.postgresql.org/docs/current/functions-aggregate.html)

> `percentile_cont`
> Computes the _continuous percentile_, a value corresponding to the specified _fraction_ within the ordered set of aggregated argument values. This will interpolate between adjacent input items if needed.
> 
> `percentile_disc`
> Computes the _discrete percentile_, the first value within the ordered set of aggregated argument values whose position in the ordering equals or exceeds the specified _fraction_. The aggregated argument must be of a sortable type.

This is a follow-up for #88