### PR TITLE
fix: retrieval stats (ttfb, car_size)

### DIFF
--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -24,6 +24,7 @@ export class Measurement {
     this.start_at = parseDateTime(m.start_at)
     this.first_byte_at = parseDateTime(m.first_byte_at)
     this.end_at = parseDateTime(m.end_at)
+    this.status_code = m.status_code
   }
 }
 

--- a/lib/retrieval-stats.js
+++ b/lib/retrieval-stats.js
@@ -60,8 +60,8 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
     const ttfb = startAt && firstByteAt && (firstByteAt - startAt)
     const duration = startAt && endAt && (endAt - startAt)
 
-    debug('size=%s ttfb=%s duration=%s valid? %s', byteLength, ttfb, duration, m.fraudAssessment === 'OK')
-    if (byteLength !== undefined) {
+    debug('size=%s ttfb=%s duration=%s status=%s valid? %s', byteLength, ttfb, duration, m.status_code, m.fraudAssessment === 'OK')
+    if (byteLength !== undefined && m.status_code === 200) {
       downloadBandwidth += byteLength
       sizeValues.push(byteLength)
     }

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -58,7 +58,7 @@ describe('retrieval statistics', () => {
     assertPointFieldValue(point, 'success_rate', '0.25')
     assertPointFieldValue(point, 'participants', '2i')
     assertPointFieldValue(point, 'inet_groups', '2i')
-    assertPointFieldValue(point, 'download_bandwidth', '209720320i')
+    assertPointFieldValue(point, 'download_bandwidth', '209718272i')
 
     assertPointFieldValue(point, 'result_rate_OK', '0.25')
     assertPointFieldValue(point, 'result_rate_TIMEOUT', '0.25')
@@ -73,9 +73,9 @@ describe('retrieval statistics', () => {
     assertPointFieldValue(point, 'duration_mean', '18500i')
     assertPointFieldValue(point, 'duration_p90', '41000i')
 
-    assertPointFieldValue(point, 'car_size_p10', '1331i')
-    assertPointFieldValue(point, 'car_size_mean', '52430080i')
-    assertPointFieldValue(point, 'car_size_p90', '146801254i')
+    assertPointFieldValue(point, 'car_size_p10', '1228i')
+    assertPointFieldValue(point, 'car_size_mean', '69906090i')
+    assertPointFieldValue(point, 'car_size_p90', '167772569i')
   })
 
   it('handles first_byte_at set to unix epoch', () => {


### PR DESCRIPTION
- fix: keep `status_code` in parsed measurements
- fix: ignore `byte_length` for non-200 status code
