### PR TITLE
fix: sorting of values for histogram calculations

### DIFF
--- a/lib/retrieval-stats.js
+++ b/lib/retrieval-stats.js
@@ -95,9 +95,9 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
 const addHistogramToPoint = (point, fieldNamePrefix, values) => {
   const count = values.length
   if (count < 1) return
-  values.sort()
+  values.sort((a, b) => a - b)
   point.intField(`${fieldNamePrefix}_min`, values[0])
-  point.intField(`${fieldNamePrefix}_mean`, values.reduce((sum, v) => sum + v, 0) / count)
+  point.intField(`${fieldNamePrefix}_mean`, values.reduce((sum, v) => sum + BigInt(v), 0n) / BigInt(count))
   point.intField(`${fieldNamePrefix}_max`, values[count - 1])
   for (const p of [10, 50, 90, 95]) {
     point.intField(`${fieldNamePrefix}_p${p}`, getValueAtPercentile(values, p))

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -37,7 +37,7 @@ describe('retrieval statistics', () => {
         participantAddress: '0xcheater',
         inet_group: 'abcd',
         start_at: new Date('2023-11-01T09:00:00.000Z').getTime(),
-        first_byte_at: new Date('2023-11-01T09:00:10.000Z').getTime(),
+        first_byte_at: new Date('2023-11-01T09:10:10.000Z').getTime(),
         end_at: new Date('2023-11-01T09:00:20.000Z').getTime(),
         finished_at: new Date('2023-11-01T09:00:30.000Z').getTime(),
         byte_length: 2048,
@@ -68,6 +68,7 @@ describe('retrieval statistics', () => {
     assertPointFieldValue(point, 'ttfb_min', '1000i')
     assertPointFieldValue(point, 'ttfb_mean', '4000i')
     assertPointFieldValue(point, 'ttfb_p90', '8199i')
+    assertPointFieldValue(point, 'ttfb_max', '10000i')
 
     assertPointFieldValue(point, 'duration_p10', '2000i')
     assertPointFieldValue(point, 'duration_mean', '18500i')
@@ -76,6 +77,7 @@ describe('retrieval statistics', () => {
     assertPointFieldValue(point, 'car_size_p10', '1228i')
     assertPointFieldValue(point, 'car_size_mean', '69906090i')
     assertPointFieldValue(point, 'car_size_p90', '167772569i')
+    assertPointFieldValue(point, 'car_size_max', '209715200i')
   })
 
   it('handles first_byte_at set to unix epoch', () => {


### PR DESCRIPTION
JavaScript's `sort()` method sort lexicographicaly, i.e. `10` < `2`.

I am fixing this problem by providing a custom comparator.
