### PR TITLE
feat: record subnets/participants/instances per task

### DIFF
--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -1,7 +1,7 @@
 import createDebug from 'debug'
 import assert from 'node:assert'
 import * as Sentry from '@sentry/node'
-import { buildRetrievalStats, recordSubnetsPerTask } from './retrieval-stats.js'
+import { buildRetrievalStats, recordCommitteeSizes } from './retrieval-stats.js'
 
 const debug = createDebug('spark:evaluate')
 
@@ -157,12 +157,12 @@ export const evaluate = async ({
   }
 
   try {
-    recordTelemetry('subnets_per_task', (point) => {
+    recordTelemetry('committees', (point) => {
       point.intField('round_index', roundIndex)
-      recordSubnetsPerTask(measurements, point)
+      recordCommitteeSizes(measurements, point)
     })
   } catch (err) {
-    console.error('Cannot record subnets-per-task.', err)
+    console.error('Cannot record committees.', err)
     Sentry.captureException(err)
   }
 }

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -1,7 +1,7 @@
 import createDebug from 'debug'
 import assert from 'node:assert'
 import * as Sentry from '@sentry/node'
-import { buildRetrievalStats } from './retrieval-stats.js'
+import { buildRetrievalStats, recordSubnetsPerTask } from './retrieval-stats.js'
 
 const debug = createDebug('spark:evaluate')
 
@@ -153,6 +153,16 @@ export const evaluate = async ({
     })
   } catch (err) {
     console.error('Cannot record retrieval stats (all).', err)
+    Sentry.captureException(err)
+  }
+
+  try {
+    recordTelemetry('subnets_per_task', (point) => {
+      point.intField('round_index', roundIndex)
+      recordSubnetsPerTask(measurements, point)
+    })
+  } catch (err) {
+    console.error('Cannot record subnets-per-task.', err)
     Sentry.captureException(err)
   }
 }

--- a/lib/retrieval-stats.js
+++ b/lib/retrieval-stats.js
@@ -77,9 +77,9 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
   telemetryPoint.intField('measurements', totalCount)
   telemetryPoint.intField('download_bandwidth', downloadBandwidth)
 
-  addHistogramToPoint(telemetryPoint, 'ttfb', ttfbValues)
-  addHistogramToPoint(telemetryPoint, 'duration', durationValues)
-  addHistogramToPoint(telemetryPoint, 'car_size', sizeValues)
+  addHistogramToPoint(telemetryPoint, ttfbValues, 'ttfb_')
+  addHistogramToPoint(telemetryPoint, durationValues, 'duration_')
+  addHistogramToPoint(telemetryPoint, sizeValues, 'car_size_')
 
   for (const [result, count] of Object.entries(resultBreakdown)) {
     telemetryPoint.floatField(`result_rate_${result}`, count / totalCount)
@@ -92,15 +92,15 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
  * @param {string} fieldNamePrefix
  * @param {number[]} values
  */
-const addHistogramToPoint = (point, fieldNamePrefix, values) => {
+const addHistogramToPoint = (point, values, fieldNamePrefix = '') => {
   const count = values.length
   if (count < 1) return
   values.sort((a, b) => a - b)
-  point.intField(`${fieldNamePrefix}_min`, values[0])
-  point.intField(`${fieldNamePrefix}_mean`, values.reduce((sum, v) => sum + BigInt(v), 0n) / BigInt(count))
-  point.intField(`${fieldNamePrefix}_max`, values[count - 1])
+  point.intField(`${fieldNamePrefix}min`, values[0])
+  point.intField(`${fieldNamePrefix}mean`, values.reduce((sum, v) => sum + BigInt(v), 0n) / BigInt(count))
+  point.intField(`${fieldNamePrefix}max`, values[count - 1])
   for (const p of [10, 50, 90, 95]) {
-    point.intField(`${fieldNamePrefix}_p${p}`, getValueAtPercentile(values, p))
+    point.intField(`${fieldNamePrefix}p${p}`, getValueAtPercentile(values, p))
   }
 }
 
@@ -142,4 +142,30 @@ const countUniqueTasks = (measurements) => {
   }
 
   return uniqueTasks.size
+}
+
+/**
+ * @param {import('./typings').Measurement[]} measurements
+ * @param {import('./typings').Point} telemetryPoint
+ */
+export const recordSubnetsPerTask = (measurements, point) => {
+  /** @type {Map<string, Set<string>>} */
+  const tasks = new Map()
+  for (const m of measurements) {
+    const key = `${m.cid}::${m.protocol}::${m.provider_address}`
+    let subnets = tasks.get(key)
+    if (!subnets) {
+      subnets = new Set()
+      tasks.set(key, subnets)
+    }
+    subnets.add(m.inet_group)
+  }
+
+  /** @type {Array<number>} */
+  const counts = []
+  for (const subnets of tasks.values()) {
+    counts.push(subnets.size)
+  }
+
+  addHistogramToPoint(point, counts)
 }

--- a/lib/retrieval-stats.js
+++ b/lib/retrieval-stats.js
@@ -148,24 +148,40 @@ const countUniqueTasks = (measurements) => {
  * @param {import('./typings').Measurement[]} measurements
  * @param {import('./typings').Point} telemetryPoint
  */
-export const recordSubnetsPerTask = (measurements, point) => {
-  /** @type {Map<string, Set<string>>} */
+export const recordCommitteeSizes = (measurements, point) => {
+  /** @type {Map<string, {subnets: Set<string>, participants: Set<string>, instances: Set<string>>} */
   const tasks = new Map()
   for (const m of measurements) {
     const key = `${m.cid}::${m.protocol}::${m.provider_address}`
-    let subnets = tasks.get(key)
-    if (!subnets) {
-      subnets = new Set()
-      tasks.set(key, subnets)
+    let data = tasks.get(key)
+    if (!data) {
+      data = {
+        subnets: new Set(),
+        participants: new Set(),
+        instances: new Set()
+      }
+      tasks.set(key, data)
     }
-    subnets.add(m.inet_group)
+    data.subnets.add(m.inet_group)
+    data.participants.add(m.participantAddress)
+    // We don't have Station instance identifier in the measurement.
+    // The pair (inet_group, participant_address) is a good approximation.
+    data.instances.add(`${m.inet_group}::${m.participantAddress}`)
   }
 
   /** @type {Array<number>} */
-  const counts = []
-  for (const subnets of tasks.values()) {
-    counts.push(subnets.size)
+  const subnetCounts = []
+  /** @type {Array<number>} */
+  const participantCounts = []
+  /** @type {Array<number>} */
+  const instanceCounts = []
+  for (const { subnets, participants, instances } of tasks.values()) {
+    subnetCounts.push(subnets.size)
+    participantCounts.push(participants.size)
+    instanceCounts.push(instances.size)
   }
 
-  addHistogramToPoint(point, counts)
+  addHistogramToPoint(point, subnetCounts, 'subnets_')
+  addHistogramToPoint(point, participantCounts, 'participants_')
+  addHistogramToPoint(point, instanceCounts, 'instances_')
 }

--- a/lib/retrieval-stats.js
+++ b/lib/retrieval-stats.js
@@ -149,7 +149,12 @@ const countUniqueTasks = (measurements) => {
  * @param {import('./typings').Point} telemetryPoint
  */
 export const recordCommitteeSizes = (measurements, point) => {
-  /** @type {Map<string, {subnets: Set<string>, participants: Set<string>, instances: Set<string>>} */
+  /** @type {Map<string, {
+   * subnets: Set<string>;
+   * participants: Set<string>;
+   * instances: Set<string>;
+   * measurements: number
+   * }>} */
   const tasks = new Map()
   for (const m of measurements) {
     const key = `${m.cid}::${m.protocol}::${m.provider_address}`
@@ -158,7 +163,8 @@ export const recordCommitteeSizes = (measurements, point) => {
       data = {
         subnets: new Set(),
         participants: new Set(),
-        instances: new Set()
+        instances: new Set(),
+        measurements: 0
       }
       tasks.set(key, data)
     }
@@ -167,6 +173,7 @@ export const recordCommitteeSizes = (measurements, point) => {
     // We don't have Station instance identifier in the measurement.
     // The pair (inet_group, participant_address) is a good approximation.
     data.instances.add(`${m.inet_group}::${m.participantAddress}`)
+    data.measurements++
   }
 
   /** @type {Array<number>} */
@@ -175,13 +182,17 @@ export const recordCommitteeSizes = (measurements, point) => {
   const participantCounts = []
   /** @type {Array<number>} */
   const instanceCounts = []
-  for (const { subnets, participants, instances } of tasks.values()) {
+  /** @type {Array<number>} */
+  const measurementCounts = []
+  for (const { subnets, participants, instances, measurements } of tasks.values()) {
     subnetCounts.push(subnets.size)
     participantCounts.push(participants.size)
     instanceCounts.push(instances.size)
+    measurementCounts.push(measurements)
   }
 
   addHistogramToPoint(point, subnetCounts, 'subnets_')
   addHistogramToPoint(point, participantCounts, 'participants_')
   addHistogramToPoint(point, instanceCounts, 'instances_')
+  addHistogramToPoint(point, measurementCounts, 'measurements_')
 }

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -137,6 +137,7 @@ describe('recordSubnetsPerTasks', () => {
       {
         ...VALID_MEASUREMENT,
         participantAddress: '0xanother',
+        // duplicate measurement in the same subnet, should be ignored
         inet_group: 'ig1'
       },
       {
@@ -161,8 +162,8 @@ describe('recordSubnetsPerTasks', () => {
     debug(point.name, point.fields)
 
     assertPointFieldValue(point, 'min', '1i')
-    assertPointFieldValue(point, 'mean', '2i') // (4+1)/2 rounded down
-    assertPointFieldValue(point, 'p50', '2i') // (4+1)/2 rounded down
+    assertPointFieldValue(point, 'mean', '2i') // (3+1)/2 rounded down
+    assertPointFieldValue(point, 'p50', '2i') // (3+1)/2 rounded down
     assertPointFieldValue(point, 'max', '3i')
   })
 })

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -4,7 +4,7 @@ import { Point } from '../lib/telemetry.js'
 import {
   buildRetrievalStats,
   getValueAtPercentile,
-  recordSubnetsPerTask
+  recordCommitteeSizes
 } from '../lib/retrieval-stats.js'
 import { VALID_MEASUREMENT } from './helpers/test-data.js'
 import { assertPointFieldValue } from './helpers/assertions.js'
@@ -126,7 +126,7 @@ describe('getValueAtPercentile', () => {
   })
 })
 
-describe('recordSubnetsPerTasks', () => {
+describe('recordCommitteeSizes', () => {
   it('reports unique subnets', async () => {
     const measurements = [
       // task 1
@@ -157,13 +157,95 @@ describe('recordSubnetsPerTasks', () => {
 
     ]
 
-    const point = new Point('subnets_per_task')
-    recordSubnetsPerTask(measurements, point)
+    const point = new Point('committees')
+    recordCommitteeSizes(measurements, point)
     debug(point.name, point.fields)
 
-    assertPointFieldValue(point, 'min', '1i')
-    assertPointFieldValue(point, 'mean', '2i') // (3+1)/2 rounded down
-    assertPointFieldValue(point, 'p50', '2i') // (3+1)/2 rounded down
-    assertPointFieldValue(point, 'max', '3i')
+    assertPointFieldValue(point, 'subnets_min', '1i')
+    assertPointFieldValue(point, 'subnets_mean', '2i') // (3+1)/2 rounded down
+    assertPointFieldValue(point, 'subnets_p50', '2i') // (3+1)/2 rounded down
+    assertPointFieldValue(point, 'subnets_max', '3i')
+  })
+
+  it('reports unique participants', async () => {
+    const measurements = [
+      // task 1
+      {
+        ...VALID_MEASUREMENT,
+        participantAddress: '0xone'
+      },
+      {
+        ...VALID_MEASUREMENT,
+        inet_group: 'ig1',
+        // duplicate measurement by the same participant, should be ignored
+        participantAddress: '0xone'
+      },
+      {
+        ...VALID_MEASUREMENT,
+        participantAddress: '0xtwo'
+      },
+      {
+        ...VALID_MEASUREMENT,
+        participantAddress: '0xthree'
+      },
+
+      // task 2
+      {
+        ...VALID_MEASUREMENT,
+        cid: 'bafyanother'
+      }
+
+    ]
+
+    const point = new Point('committees')
+    recordCommitteeSizes(measurements, point)
+    debug(point.name, point.fields)
+
+    assertPointFieldValue(point, 'participants_min', '1i')
+    assertPointFieldValue(point, 'participants_mean', '2i') // (3+1)/2 rounded down
+    assertPointFieldValue(point, 'participants_p50', '2i') // (3+1)/2 rounded down
+    assertPointFieldValue(point, 'participants_max', '3i')
+  })
+
+  it('reports unique instances', async () => {
+    const measurements = [
+      // task 1
+      {
+        ...VALID_MEASUREMENT,
+        inet_group: 'ig1',
+        participantAddress: '0xone'
+      },
+      {
+        ...VALID_MEASUREMENT,
+        // duplicate measurement by the same participant in the same subnet, should be ignored
+        inet_group: 'ig1',
+        participantAddress: '0xone'
+      },
+      {
+        ...VALID_MEASUREMENT,
+        // same participant address but different subnet
+        inet_group: 'ig2',
+        participantAddress: '0xone'
+      },
+      {
+        ...VALID_MEASUREMENT
+      },
+
+      // task 2
+      {
+        ...VALID_MEASUREMENT,
+        cid: 'bafyanother'
+      }
+
+    ]
+
+    const point = new Point('committees')
+    recordCommitteeSizes(measurements, point)
+    debug(point.name, point.fields)
+
+    assertPointFieldValue(point, 'instances_min', '1i')
+    assertPointFieldValue(point, 'instances_mean', '2i') // (3+1)/2 rounded down
+    assertPointFieldValue(point, 'instances_p50', '2i') // (3+1)/2 rounded down
+    assertPointFieldValue(point, 'instances_max', '3i')
   })
 })

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -248,4 +248,36 @@ describe('recordCommitteeSizes', () => {
     assertPointFieldValue(point, 'instances_p50', '2i') // (3+1)/2 rounded down
     assertPointFieldValue(point, 'instances_max', '3i')
   })
+
+  it('reports number of all measurements', async () => {
+    const measurements = [
+      // task 1
+      {
+        ...VALID_MEASUREMENT
+      },
+      {
+        ...VALID_MEASUREMENT
+
+      },
+      {
+        ...VALID_MEASUREMENT
+      },
+
+      // task 2
+      {
+        ...VALID_MEASUREMENT,
+        cid: 'bafyanother'
+      }
+
+    ]
+
+    const point = new Point('committees')
+    recordCommitteeSizes(measurements, point)
+    debug(point.name, point.fields)
+
+    assertPointFieldValue(point, 'measurements_min', '1i')
+    assertPointFieldValue(point, 'measurements_mean', '2i') // (3+1)/2 rounded down
+    assertPointFieldValue(point, 'measurements_p50', '2i') // (3+1)/2 rounded down
+    assertPointFieldValue(point, 'measurements_max', '3i')
+  })
 })


### PR DESCRIPTION
Help us understand how many data points we have for each task (what is the effective committee size). Are the committees always large enough to give us enough confidence in finding an honest majority?

Also, record how many measurements (retrieval checks) we provide for each task to understand how much load we put on SPs.

InfluxDB point name: `committees`
Field prefixes:
- `subnets_`
- `participants_`
- `instances_`
- `measurements_` (all measurements, independent of fraud assessment)

Links:
- https://github.com/filecoin-station/spark-api/pull/171
- https://github.com/filecoin-station/spark/issues/45
- https://github.com/filecoin-station/roadmap/issues/52