### PR TITLE
feat: report nodes participating in a round

### DIFF
--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -116,7 +116,7 @@ export const evaluate = async ({
     point.intField('round_index', roundIndex)
     point.intField('total_participants', Object.keys(participants).length)
     point.intField('total_measurements', measurements.length)
-    point.intField('total_instances', countStationInstances(measurements))
+    point.intField('total_nodes', countUniqueNodes(measurements))
     point.intField('honest_measurements', honestMeasurements.length)
     point.intField('set_scores_duration_ms', setScoresDuration)
     point.intField('fraud_detection_duration_ms', fraudDetectionDuration)
@@ -357,7 +357,7 @@ const calculateInetGroupSuccessRates = (taskGroups) => {
 /**
  * @param {import('./typings').Measurement[]}
  */
-const countStationInstances = (measurements) => {
+const countUniqueNodes = (measurements) => {
   const instances = new Set()
   for (const m of measurements) {
     const key = `${m.inet_group}::${m.participantAddress}`

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -358,10 +358,10 @@ const calculateInetGroupSuccessRates = (taskGroups) => {
  * @param {import('./typings').Measurement[]}
  */
 const countUniqueNodes = (measurements) => {
-  const instances = new Set()
+  const nodes = new Set()
   for (const m of measurements) {
     const key = `${m.inet_group}::${m.participantAddress}`
-    instances.add(key)
+    nodes.add(key)
   }
-  return instances.size
+  return nodes.size
 }

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -115,6 +115,7 @@ export const evaluate = async ({
     point.intField('round_index', roundIndex)
     point.intField('total_participants', Object.keys(participants).length)
     point.intField('total_measurements', measurements.length)
+    point.intField('total_instances', countStationInstances(measurements))
     point.intField('honest_measurements', honestMeasurements.length)
     point.intField('set_scores_duration_ms', setScoresDuration)
     point.intField('fraud_detection_duration_ms', fraudDetectionDuration)
@@ -337,4 +338,16 @@ const calculateInetGroupSuccessRates = (taskGroups) => {
 
   debug('Winning rates stats: %o', result)
   return result
+}
+
+/**
+ * @param {import('./typings').Measurement[]}
+ */
+const countStationInstances = (measurements) => {
+  const instances = new Set()
+  for (const m of measurements) {
+    const key = `${m.inet_group}::${m.participantAddress}`
+    instances.add(key)
+  }
+  return instances.size
 }

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -56,7 +56,8 @@ describe('evaluate', () => {
     const point = telemetry.find(p => p.name === 'evaluate')
     assert(!!point,
       `No telemetry point "evaluate" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
-    // TODO: assert point fields
+    assertPointFieldValue(point, 'total_instances', '1i')
+    // TODO: assert more point fields
   })
   it('handles empty rounds', async () => {
     const rounds = { 0: new RoundData() }
@@ -181,6 +182,8 @@ describe('evaluate', () => {
     assertPointFieldValue(point, 'group_winning_min', '1')
     assertPointFieldValue(point, 'group_winning_mean', '1')
     assertPointFieldValue(point, 'group_winning_max', '1')
+
+    assertPointFieldValue(point, 'total_instances', '3i')
   })
 
   it('adds a dummy entry to ensure scores add up exactly to MAX_SCORE', async () => {

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -56,7 +56,7 @@ describe('evaluate', () => {
     const point = telemetry.find(p => p.name === 'evaluate')
     assert(!!point,
       `No telemetry point "evaluate" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
-    assertPointFieldValue(point, 'total_instances', '1i')
+    assertPointFieldValue(point, 'total_nodes', '1i')
     // TODO: assert more point fields
   })
   it('handles empty rounds', async () => {
@@ -183,7 +183,7 @@ describe('evaluate', () => {
     assertPointFieldValue(point, 'group_winning_mean', '1')
     assertPointFieldValue(point, 'group_winning_max', '1')
 
-    assertPointFieldValue(point, 'total_instances', '3i')
+    assertPointFieldValue(point, 'total_nodes', '3i')
   })
 
   it('adds a dummy entry to ensure scores add up exactly to MAX_SCORE', async () => {

--- a/test/spark-api.js
+++ b/test/spark-api.js
@@ -6,7 +6,7 @@ const recordTelemetry = (measurementName, fn) => { /* no-op */ }
 describe('spark-api client', () => {
   it('fetches round details', async function () {
     this.timeout(10_000)
-    const { retrievalTasks, ...details } = await fetchRoundDetails(
+    const { retrievalTasks, maxTasksPerNode, ...details } = await fetchRoundDetails(
       '0xaaef78eaf86dcf34f275288752e892424dda9341',
       407,
       recordTelemetry
@@ -15,6 +15,8 @@ describe('spark-api client', () => {
     assert.deepStrictEqual(details, {
       roundId: '3405' // BigInt serialized as String
     })
+
+    assert.strictEqual(typeof maxTasksPerNode, 'number')
 
     assert.strictEqual(retrievalTasks.length, 400)
     assert.deepStrictEqual(retrievalTasks.slice(0, 2), [

--- a/test/spark-api.js
+++ b/test/spark-api.js
@@ -13,8 +13,7 @@ describe('spark-api client', () => {
     )
 
     assert.deepStrictEqual(details, {
-      roundId: '3405', // BigInt serialized as String
-      maxTasksPerNode: 360
+      roundId: '3405' // BigInt serialized as String
     })
 
     assert.strictEqual(typeof maxTasksPerNode, 'number')


### PR DESCRIPTION
- test: handle maxTasksPerNode in round details
- feat: report ~~instances~~ nodes participating in a round

Count the number of unique `(inet_group, participant_address)` nodes participating in the evaluated round and record it as another telemetry field.

Point name: `evaluate`
Field name: `total_nodes`

**IMPORTANT: the number of nodes calculated this way WILL BE DIFFERENT from the number of Station instances obtained from "ping" points.**

Related:
- https://github.com/filecoin-station/spark-evaluate/pull/97