### PR TITLE
feat: rename fields `instances_*` to `nodes_*`

### DIFF
--- a/lib/retrieval-stats.js
+++ b/lib/retrieval-stats.js
@@ -152,7 +152,7 @@ export const recordCommitteeSizes = (measurements, point) => {
   /** @type {Map<string, {
    * subnets: Set<string>;
    * participants: Set<string>;
-   * instances: Set<string>;
+   * nodes: Set<string>;
    * measurements: number
    * }>} */
   const tasks = new Map()
@@ -163,7 +163,7 @@ export const recordCommitteeSizes = (measurements, point) => {
       data = {
         subnets: new Set(),
         participants: new Set(),
-        instances: new Set(),
+        nodes: new Set(),
         measurements: 0
       }
       tasks.set(key, data)
@@ -172,7 +172,7 @@ export const recordCommitteeSizes = (measurements, point) => {
     data.participants.add(m.participantAddress)
     // We don't have Station instance identifier in the measurement.
     // The pair (inet_group, participant_address) is a good approximation.
-    data.instances.add(`${m.inet_group}::${m.participantAddress}`)
+    data.nodes.add(`${m.inet_group}::${m.participantAddress}`)
     data.measurements++
   }
 
@@ -181,18 +181,18 @@ export const recordCommitteeSizes = (measurements, point) => {
   /** @type {Array<number>} */
   const participantCounts = []
   /** @type {Array<number>} */
-  const instanceCounts = []
+  const nodeCounts = []
   /** @type {Array<number>} */
   const measurementCounts = []
-  for (const { subnets, participants, instances, measurements } of tasks.values()) {
+  for (const { subnets, participants, nodes, measurements } of tasks.values()) {
     subnetCounts.push(subnets.size)
     participantCounts.push(participants.size)
-    instanceCounts.push(instances.size)
+    nodeCounts.push(nodes.size)
     measurementCounts.push(measurements)
   }
 
   addHistogramToPoint(point, subnetCounts, 'subnets_')
   addHistogramToPoint(point, participantCounts, 'participants_')
-  addHistogramToPoint(point, instanceCounts, 'instances_')
+  addHistogramToPoint(point, nodeCounts, 'nodes_')
   addHistogramToPoint(point, measurementCounts, 'measurements_')
 }

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -207,7 +207,7 @@ describe('recordCommitteeSizes', () => {
     assertPointFieldValue(point, 'participants_max', '3i')
   })
 
-  it('reports unique instances', async () => {
+  it('reports unique nodes', async () => {
     const measurements = [
       // task 1
       {
@@ -243,10 +243,10 @@ describe('recordCommitteeSizes', () => {
     recordCommitteeSizes(measurements, point)
     debug(point.name, point.fields)
 
-    assertPointFieldValue(point, 'instances_min', '1i')
-    assertPointFieldValue(point, 'instances_mean', '2i') // (3+1)/2 rounded down
-    assertPointFieldValue(point, 'instances_p50', '2i') // (3+1)/2 rounded down
-    assertPointFieldValue(point, 'instances_max', '3i')
+    assertPointFieldValue(point, 'nodes_min', '1i')
+    assertPointFieldValue(point, 'nodes_mean', '2i') // (3+1)/2 rounded down
+    assertPointFieldValue(point, 'nodes_p50', '2i') // (3+1)/2 rounded down
+    assertPointFieldValue(point, 'nodes_max', '3i')
   })
 
   it('reports number of all measurements', async () => {


### PR DESCRIPTION
Rename the fields in "committees" metric to use "nodes" instead of "instances" as the name prefix for consistency with the rest of SPARK stack and design docs.

This is a follow-up for #100

The tests are expected to fail until we land #100.
