### PR TITLE
limit `setScores` arguments length

### DIFF
--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -6,6 +6,36 @@ import { buildRetrievalStats, recordCommitteeSizes } from './retrieval-stats.js'
 const debug = createDebug('spark:evaluate')
 
 export const MAX_SCORE = 1_000_000_000_000_000n
+export const MAX_SET_SCORES_PARTICIPANTS = 500
+
+export class SetScoresBucket {
+  constructor () {
+    this.participants = []
+    this.scores = []
+  }
+
+  add (participant, score) {
+    this.participants.push(participant)
+    this.scores.push(score)
+  }
+
+  get size () {
+    return this.participants.length
+  }
+}
+
+export const createSetScoresBuckets = participants => {
+  const buckets = [new SetScoresBucket()]
+  for (const [participant, score] of Object.entries(participants)) {
+    let currentBucket = buckets[buckets.length - 1]
+    if (currentBucket.size === MAX_SET_SCORES_PARTICIPANTS) {
+      currentBucket = new SetScoresBucket()
+      buckets.push(currentBucket)
+    }
+    currentBucket.add(participant, score)
+  }
+  return buckets
+}
 
 /**
  * @param {object} args
@@ -101,13 +131,22 @@ export const evaluate = async ({
   )
 
   const start = new Date()
-  const tx = await ieContractWithSigner.setScores(
-    roundIndex,
-    Object.keys(participants),
-    Object.values(participants)
-  )
+  const buckets = createSetScoresBuckets(participants)
+  for (const [bucketIndex, bucket] of Object.entries(buckets)) {
+    const tx = await ieContractWithSigner.setScores(
+      roundIndex,
+      bucket.participants,
+      bucket.scores
+    )
+    logger.log(
+      'EVALUATE ROUND %s: IE.setScores() TX hash: %s CALL: %s/%s',
+      roundIndex,
+      tx.hash,
+      bucketIndex,
+      buckets.length
+    )
+  }
   const setScoresDuration = new Date() - start
-  logger.log('EVALUATE ROUND %s: IE.setScores() TX hash: %s', roundIndex, tx.hash)
 
   // Clean up
   delete rounds[roundIndex]

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -1,4 +1,4 @@
-import { MAX_SCORE, evaluate, runFraudDetection } from '../lib/evaluate.js'
+import { MAX_SCORE, evaluate, runFraudDetection, MAX_SET_SCORES_PARTICIPANTS, createSetScoresBuckets, SetScoresBucket } from '../lib/evaluate.js'
 import { Point } from '../lib/telemetry.js'
 import assert from 'node:assert'
 import { ethers } from 'ethers'
@@ -493,5 +493,21 @@ describe('fraud detection', () => {
       measurements.map(m => m.fraudAssessment),
       ['OK', 'TOO_MANY_TASKS', 'OK']
     )
+  })
+})
+
+describe('set scores buckets', () => {
+  it('splits contract calls with many participants', async () => {
+    const participants = {}
+    for (let i = 0; i < MAX_SET_SCORES_PARTICIPANTS + 1; i++) {
+      participants[`0x${i}`] = BigNumber.from(1_000_000_000_000_000)
+    }
+    const buckets = createSetScoresBuckets(participants)
+    assert.strictEqual(buckets.length, 2)
+    assert.strictEqual(buckets[0].size, MAX_SET_SCORES_PARTICIPANTS)
+    assert.strictEqual(buckets[1].size, 1)
+    const bucket = new SetScoresBucket()
+    bucket.add(`0x${MAX_SET_SCORES_PARTICIPANTS}`, BigNumber.from(1_000_000_000_000_000))
+    assert.deepStrictEqual(buckets[1], bucket)
   })
 })


### PR DESCRIPTION
In order not to run into smart contract argument length limitations
