### PR TITLE
feat: add a script to fetch committed measurements

### DIFF
--- a/bin/fetch-measurements.js
+++ b/bin/fetch-measurements.js
@@ -1,0 +1,97 @@
+/*
+Usage:
+
+1. Setup port forwarding between your local computer and Postgres instance hosted by Fly.io
+  ([docs](https://fly.io/docs/postgres/connecting/connecting-with-flyctl/)). Remember to use a
+  different port if you have a local Postgres server for development!
+   ```sh
+   fly proxy 5454:5432 -a spark-db
+   ```
+
+2. Find spark-db entry in 1Password and get the user and password from the connection string.
+
+3. Run the following command to fetch all measurements, remember to replace "user" and "password"
+   with the real credentials:
+
+   ```sh
+   DATABASE_URL="postgres://user:password@localhost:5454/spark" node bin/fetch-measurements.js <range-start> <range-end> > measurements.ndjson
+   ```
+
+   This will fetch all measurements committed between range-start (inclusive) and range-end (exclusive)
+   and write them to `measurements.ndjson` in the current directory.
+
+The script prints prints measurement in NDJSON format to stdout and progress information to stderr.
+*/
+
+import pg from 'pg'
+import { fetchMeasurements } from '../lib/preprocess.js'
+
+const { DATABASE_URL } = process.env
+
+const [,, startStr, endStr] = process.argv
+
+const printUsage = () => {
+  console.error(`
+Usage:
+  ${process.argv[0]} ${process.argv[1]} <range-start> <range-end>
+
+Example
+  ${process.argv[0]} ${process.argv[1]} 2024-01-01T00:00:00Z 2024-01-02T00:00:00Z
+  `)
+}
+
+if (!startStr) {
+  console.error('Missing argument: range-start')
+  printUsage()
+  process.exit(1)
+}
+
+const start = new Date(startStr)
+if (Number.isNaN(start.getTime())) {
+  console.error('Invalid range-start: not a valid date-time string')
+  printUsage()
+  process.exit(1)
+}
+
+if (!endStr) {
+  console.error('Missing argument: range-end')
+  printUsage()
+  process.exit(1)
+}
+
+const end = new Date(endStr)
+if (Number.isNaN(end.getTime())) {
+  console.error('Invalid range-end: not a valid date-time string')
+  printUsage()
+  process.exit(1)
+}
+
+console.error('Fetching measurements committed between %j and %j', start, end)
+const client = new pg.Client({ connectionString: DATABASE_URL })
+await client.connect()
+
+const { rows } = await client.query(`
+  SELECT cid FROM commitments
+  WHERE published_at >= $1 AND published_at < $2
+  `, [
+  start,
+  end
+])
+const cids = rows.map(r => r.cid)
+
+console.error('Found %s commitments', cids.length)
+
+for await (const c of cids) {
+  console.error('  fetching %s', c)
+  try {
+    const measurements = await fetchMeasurements(c)
+    for (const m of measurements) {
+      console.log(JSON.stringify(m))
+    }
+  } catch (err) {
+    console.error('**ALERT** skipping %s: %s', c, err)
+  }
+}
+
+console.error('Done')
+await client.end()

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "mocha": "^10.2.0",
+        "pg": "^8.11.3",
         "standard": "^17.1.0"
       }
     },
@@ -1590,6 +1591,15 @@
       "integrity": "sha512-GlxfuD/NrKvCNs0Ut+7b1IHjylfdegMBxQIlZHj7bObKVQBxB5S84gtm2yu1mQ8/sSggceWBDPY0cPXgvX2MuA==",
       "dependencies": {
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/buffer-writer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
+      "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/builtins": {
@@ -4303,6 +4313,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/packet-reader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
+      "dev": true
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4360,6 +4376,97 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/pg": {
+      "version": "8.11.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
+      "integrity": "sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==",
+      "dev": true,
+      "dependencies": {
+        "buffer-writer": "2.0.0",
+        "packet-reader": "1.0.0",
+        "pg-connection-string": "^2.6.2",
+        "pg-pool": "^3.6.1",
+        "pg-protocol": "^1.6.0",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.1"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+      "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "dev": true,
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
+      "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==",
+      "dev": true
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
+      "integrity": "sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==",
+      "dev": true,
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
+      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q==",
+      "dev": true
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -4454,6 +4561,45 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/prelude-ls": {
@@ -4841,6 +4987,15 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/sparse-array/-/sparse-array-1.3.2.tgz",
       "integrity": "sha512-ZT711fePGn3+kQyLuv1fpd3rNSkNF8vd5Kv2D+qnOANeyKs3fx6bUMGWRPvgTTcYV64QMqZKZwcuaQSP3AZ0tg=="
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.x"
+      }
     },
     "node_modules/standard": {
       "version": "17.1.0",
@@ -5401,6 +5556,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   },
   "devDependencies": {
     "mocha": "^10.2.0",
+    "pg": "^8.11.3",
     "standard": "^17.1.0"
   },
   "dependencies": {


### PR DESCRIPTION
This is a follow-up for https://github.com/filecoin-station/spark-api/pull/184. My intention is to implement the integration bits while I remember the details. Improving the new script to store measurements in a more useful format (e.g. feed it to Postgres or SQLite) is out of the scope.

Example usage:

```
❯ DATABASE_URL="postgres://redacted:redacted@localhost:5454/spark" node bin/fetch-measurements.js 2024-01-04T00:00:00Z 2024-01-04T00:15:00Z> measurements.ndjson
Fetching measurements committed between "2024-01-04T00:00:00.000Z" and "2024-01-04T00:15:00.000Z"
Found 8 commitments
  fetching bafybeihpv77mcbbnkss7umjcnjcvizki3nky7s5kh2ys2upvx6skjxf5lm
  fetching bafybeicnmtnrnrbcejabdxm264ttt2obmke2acsriww7lbopp66zewmoia
  fetching bafybeieeqbdovjpwsd5f4fudhhkwa4p6c6fzgsmyxksve5dsx6ic3ej4d4
  fetching bafybeidijh4mhiexehzqojf3hh7isjbsxcgxt2coanc5nkejuocs4fucyy
  fetching bafybeib3umca5lp5zqiz3bnrjzmdtoqwz5e5lf4vxpnimo4jbmbqjr36ta
  fetching bafybeifouyrmwkv7iqobrzx32meibo63al3jzt4joavovzkkswuw4stfoe
  fetching bafybeid5zujpeq5mjl2slqbbmngshanjhyskf4xymembprsvwse6bfexc4
  fetching bafybeieo676fducim2wnumucy3q5lnhzdwzyltkh53h3vrj46t2wxvywau
Done
❯ wc -l measurements.ndjson
  345970 measurements.ndjson
```