### PR TITLE
refactor: use `just-percentile` instead of own impl

### DIFF
--- a/lib/retrieval-stats.js
+++ b/lib/retrieval-stats.js
@@ -1,6 +1,11 @@
 import createDebug from 'debug'
+import getValueAtPercentile from 'just-percentile'
 
 const debug = createDebug('spark:retrieval-stats')
+
+export {
+  getValueAtPercentile
+}
 
 /**
  * @param {import('./typings').Measurement[]} measurements
@@ -109,31 +114,8 @@ const addHistogramToPoint = (point, values, fieldNamePrefix = '') => {
   point.intField(`${fieldNamePrefix}mean`, values.reduce((sum, v) => sum + BigInt(v), 0n) / BigInt(count))
   point.intField(`${fieldNamePrefix}max`, values[count - 1])
   for (const p of [1, 5, 10, 50, 90, 95, 99]) {
-    point.intField(`${fieldNamePrefix}p${p}`, getValueAtPercentile(values, p))
+    point.intField(`${fieldNamePrefix}p${p}`, getValueAtPercentile(values, p / 100))
   }
-}
-
-export const getValueAtPercentile = (values, p) => {
-  // See https://www.calculatorsoup.com/calculators/statistics/percentile-calculator.php
-  // 1. Arrange n number of data points in ascending order: x1, x2, x3, ... xn
-  const n = values.length
-
-  // 2. Calculate the rank r for the percentile p you want to find: r = (p/100) * (n - 1) + 1
-  const r = (n - 1) * p / 100 + 1
-
-  // 3. If r is an integer then the data value at location r, xr, is the percentile p: p = xr
-  if (Number.isInteger(r)) {
-    // Remember that we are indexing from 0, i.e. x1 is stored in values[0]
-    return values[r - 1]
-  }
-
-  const ri = Math.floor(r)
-  const rf = r - ri
-
-  // 4. If r is not an integer, p is interpolated using ri, the integer part of r,
-  // and rf, the fractional part of r:
-  // p = xri + rf * (xri+1 - xri)
-  return values[ri - 1] + rf * (values[ri] - values[ri - 1])
 }
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "debug": "^4.3.4",
         "ethers": "^5.7.2",
         "ipfs-car": "^1.1.0",
-        "ipfs-unixfs-exporter": "^13.2.5"
+        "ipfs-unixfs-exporter": "^13.2.5",
+        "just-percentile": "^4.2.0"
       },
       "devDependencies": {
         "mocha": "^10.2.0",
@@ -3768,6 +3769,11 @@
       "engines": {
         "node": ">=4.0"
       }
+    },
+    "node_modules/just-percentile": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/just-percentile/-/just-percentile-4.2.0.tgz",
+      "integrity": "sha512-DjoYlegU7nyyi9ux9atRphMx4plC1fPgeSPkOvjg6Y3QzOx91jwi/6BDmgdb+KYBiI2glRWgHriA98NI/OWaBQ=="
     },
     "node_modules/keyv": {
       "version": "4.5.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "debug": "^4.3.4",
     "ethers": "^5.7.2",
     "ipfs-car": "^1.1.0",
-    "ipfs-unixfs-exporter": "^13.2.5"
+    "ipfs-unixfs-exporter": "^13.2.5",
+    "just-percentile": "^4.2.0"
   },
   "standard": {
     "env": [

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -124,7 +124,7 @@ describe('retrieval statistics', () => {
 describe('getValueAtPercentile', () => {
   it('interpolates the values', () => {
     assert.strictEqual(
-      getValueAtPercentile([10, 20, 30], 90),
+      getValueAtPercentile([10, 20, 30], 0.9),
       28
     )
   })


### PR DESCRIPTION
Refactor our code calculating percentiles to use a 3rd party dependency instead of our own implementation.

I discovered this while thinking how to address the discussion in my blog post:
https://github.com/bajtos/bajtos.github.io/pull/23#discussion_r1426613735

It makes me wonder why I didn't find this npm package before!

Sometimes, it's better to have more control over our code and not use 3rd-party dependencies for simple helper functions, so maybe this PR isn't an improvement.

Thoughts?
