### PR TITLE
feat: write public stats to our PG DB

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,22 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:latest
+        env:
+          POSTGRES_DB: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Set up [PostgreSQL](https://www.postgresql.org/) with default settings:
  - Port: 5432
  - User: _your system user name_
  - Password: _blank_
- - Database: spark_public
+ - Database: spark_stats
 
 Alternatively, set the environment variable `$DATABASE_URL` with
 `postgres://${USER}:${PASS}@${HOST}:${POST}/${DATABASE}`.
@@ -24,7 +24,7 @@ You can also run the following command to set up the PostgreSQL server via Docke
 docker run -d --name spark-db \
   -e POSTGRES_HOST_AUTH_METHOD=trust \
   -e POSTGRES_USER=$USER \
-  -e POSTGRES_DB=spark_public \
+  -e POSTGRES_DB=spark_stats \
   -p 5432:5432 \
   postgres
 ```

--- a/README.md
+++ b/README.md
@@ -6,9 +6,39 @@ Evaluate service
 
 ## Development
 
+Set up [PostgreSQL](https://www.postgresql.org/) with default settings:
+ - Port: 5432
+ - User: _your system user name_
+ - Password: _blank_
+ - Database: spark_public
+
+Alternatively, set the environment variable `$DATABASE_URL` with
+`postgres://${USER}:${PASS}@${HOST}:${POST}/${DATABASE}`.
+
+The Postgres user and database need to exist already, and the user
+needs full management permissions for the database.
+
+You can also run the following command to set up the PostgreSQL server via Docker:
+
+```bash
+docker run -d --name spark-db \
+  -e POSTGRES_HOST_AUTH_METHOD=trust \
+  -e POSTGRES_USER=$USER \
+  -e POSTGRES_DB=spark_public \
+  -p 5432:5432 \
+  postgres
+```
+
+## Run the tests
+
+```bash
+$ npm test
+```
+
+## Run the service
+
 ```bash
 $ WALLET_SEED=$(cat secrets/mnemonic) npm start
-$ npm test
 ```
 
 ## Troubleshooting

--- a/bin/migrate.js
+++ b/bin/migrate.js
@@ -1,11 +1,4 @@
 import { DATABASE_URL } from '../lib/config.js'
-import { migrate } from '../lib/migrate.js'
-import pg from 'pg'
+import { migrateWithPgConfig } from '../lib/migrate.js'
 
-const client = new pg.Client({ connectionString: DATABASE_URL })
-await client.connect()
-try {
-  await migrate(client)
-} finally {
-  await client.end()
-}
+await migrateWithPgConfig({ connectionString: DATABASE_URL })

--- a/bin/migrate.js
+++ b/bin/migrate.js
@@ -4,5 +4,8 @@ import pg from 'pg'
 
 const client = new pg.Client({ connectionString: DATABASE_URL })
 await client.connect()
-await migrate(client)
-await client.end()
+try {
+  await migrate(client)
+} finally {
+  await client.end()
+}

--- a/bin/migrate.js
+++ b/bin/migrate.js
@@ -1,0 +1,8 @@
+import { DATABASE_URL } from '../lib/config.js'
+import { migrate } from '../lib/migrate.js'
+import pg from 'pg'
+
+const client = new pg.Client({ connectionString: DATABASE_URL })
+await client.connect()
+await migrate(client)
+await client.end()

--- a/bin/spark-evaluate.js
+++ b/bin/spark-evaluate.js
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/node'
-import { IE_CONTRACT_ADDRESS, RPC_URL, rpcHeaders } from '../lib/config.js'
+import { DATABASE_URL, IE_CONTRACT_ADDRESS, RPC_URL, rpcHeaders } from '../lib/config.js'
 import { startEvaluate } from '../index.js'
 import { fetchRoundDetails } from '../lib/spark-api.js'
 import assert from 'node:assert'
@@ -9,6 +9,7 @@ import { newDelegatedEthAddress } from '@glif/filecoin-address'
 import { recordTelemetry } from '../lib/telemetry.js'
 import fs from 'node:fs/promises'
 import { fetchMeasurements } from '../lib/preprocess.js'
+import { migrateWithDbConfig } from '../lib/migrate.js'
 import http from 'node:http'
 
 const {
@@ -25,7 +26,7 @@ Sentry.init({
 
 assert(WALLET_SEED, 'WALLET_SEED required')
 
-await import('./migrate.js')
+await migrateWithDbConfig({ connectionString: DATABASE_URL })
 
 const provider = new ethers.providers.JsonRpcProvider({
   url: RPC_URL,

--- a/bin/spark-evaluate.js
+++ b/bin/spark-evaluate.js
@@ -9,7 +9,7 @@ import { newDelegatedEthAddress } from '@glif/filecoin-address'
 import { recordTelemetry } from '../lib/telemetry.js'
 import fs from 'node:fs/promises'
 import { fetchMeasurements } from '../lib/preprocess.js'
-import { migrateWithDbConfig } from '../lib/migrate.js'
+import { migrateWithPgConfig } from '../lib/migrate.js'
 import http from 'node:http'
 
 const {
@@ -26,7 +26,7 @@ Sentry.init({
 
 assert(WALLET_SEED, 'WALLET_SEED required')
 
-await migrateWithDbConfig({ connectionString: DATABASE_URL })
+await migrateWithPgConfig({ connectionString: DATABASE_URL })
 
 const provider = new ethers.providers.JsonRpcProvider({
   url: RPC_URL,

--- a/bin/spark-evaluate.js
+++ b/bin/spark-evaluate.js
@@ -24,6 +24,8 @@ Sentry.init({
 
 assert(WALLET_SEED, 'WALLET_SEED required')
 
+await import('./migrate.js')
+
 const provider = new ethers.providers.JsonRpcProvider({
   url: RPC_URL,
   headers: rpcHeaders

--- a/bin/spark-evaluate.js
+++ b/bin/spark-evaluate.js
@@ -10,6 +10,7 @@ import { recordTelemetry } from '../lib/telemetry.js'
 import fs from 'node:fs/promises'
 import { fetchMeasurements } from '../lib/preprocess.js'
 import { migrateWithPgConfig } from '../lib/migrate.js'
+import pg from 'pg'
 import http from 'node:http'
 
 const {
@@ -50,6 +51,12 @@ const ieContract = new ethers.Contract(
 )
 const ieContractWithSigner = ieContract.connect(signer)
 
+const createPgClient = async () => {
+  const pgClient = new pg.Client({ connectionString: DATABASE_URL })
+  await pgClient.connect()
+  return pgClient
+}
+
 // FIXME fly.io
 http.createServer((_, res) => res.end()).listen(8080)
 
@@ -59,5 +66,6 @@ startEvaluate({
   fetchMeasurements,
   fetchRoundDetails,
   recordTelemetry,
+  createPgClient,
   logger: console
 })

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import assert from 'node:assert'
 import * as Sentry from '@sentry/node'
 import { preprocess } from './lib/preprocess.js'
 import { evaluate } from './lib/evaluate.js'
@@ -8,8 +9,11 @@ export const startEvaluate = ({
   fetchMeasurements,
   fetchRoundDetails,
   recordTelemetry,
+  createPgClient,
   logger
 }) => {
+  assert(typeof createPgClient === 'function', 'createPgClient must be a function')
+
   const rounds = {}
   const cidsSeen = []
   const roundsSeen = []
@@ -62,6 +66,7 @@ export const startEvaluate = ({
       ieContractWithSigner,
       fetchRoundDetails,
       recordTelemetry,
+      createPgClient,
       logger
     }).catch(err => {
       console.error(err)

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,6 +2,7 @@ const {
   IE_CONTRACT_ADDRESS = '0xaaef78eaf86dcf34f275288752e892424dda9341',
   RPC_URLS = 'https://api.node.glif.io/rpc/v0,https://api.chain.love/rpc/v1',
   GLIF_TOKEN,
+  DATABASE_URL = 'postgres://localhost:5432/spark_public',
   SPARK_API = 'https://api.filspark.com'
 } = process.env
 
@@ -17,6 +18,7 @@ if (RPC_URL.includes('glif')) {
 export {
   IE_CONTRACT_ADDRESS,
   RPC_URL,
+  DATABASE_URL,
   SPARK_API,
   rpcHeaders
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -2,7 +2,7 @@ const {
   IE_CONTRACT_ADDRESS = '0x811765AccE724cD5582984cb35f5dE02d587CA12',
   RPC_URLS = 'https://api.node.glif.io/rpc/v0,https://api.chain.love/rpc/v1',
   GLIF_TOKEN,
-  DATABASE_URL = 'postgres://localhost:5432/spark_public',
+  DATABASE_URL = 'postgres://localhost:5432/spark_stats',
   SPARK_API = 'https://api.filspark.com'
 } = process.env
 

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -2,6 +2,7 @@ import createDebug from 'debug'
 import assert from 'node:assert'
 import * as Sentry from '@sentry/node'
 import { buildRetrievalStats, recordCommitteeSizes } from './retrieval-stats.js'
+import { updatePublicStats } from './public-stats.js'
 
 const debug = createDebug('spark:evaluate')
 
@@ -204,6 +205,13 @@ export const evaluate = async ({
     })
   } catch (err) {
     console.error('Cannot record committees.', err)
+    Sentry.captureException(err)
+  }
+
+  try {
+    await updatePublicStats(measurements)
+  } catch (err) {
+    console.error('Cannot update public stats.', err)
     Sentry.captureException(err)
   }
 }

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -45,6 +45,7 @@ export const createSetScoresBuckets = participants => {
  * @param {any} args.ieContractWithSigner
  * @param {import('./spark-api').fetchRoundDetails} args.fetchRoundDetails,
  * @param {import('./typings').RecordTelemetryFn} args.recordTelemetry
+ * @param {import('./typings').CreatePgClient} args.createPgClient
  * @param {Console} args.logger
  */
 export const evaluate = async ({
@@ -53,6 +54,7 @@ export const evaluate = async ({
   ieContractWithSigner,
   fetchRoundDetails,
   recordTelemetry,
+  createPgClient,
   logger
 }) => {
   // Get measurements
@@ -224,7 +226,7 @@ export const evaluate = async ({
   }
 
   try {
-    await updatePublicStats(measurements)
+    await updatePublicStats({ createPgClient, measurements })
   } catch (err) {
     console.error('Cannot update public stats.', err)
     Sentry.captureException(err)

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -1,0 +1,26 @@
+import Postgrator from 'postgrator'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const migrationsDirectory = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'migrations'
+)
+
+export const migrate = async (client) => {
+  const postgrator = new Postgrator({
+    migrationPattern: join(migrationsDirectory, '*'),
+    driver: 'pg',
+    execQuery: (query) => client.query(query)
+  })
+  console.log(
+    'Migrating DB schema from version %s to version %s',
+    await postgrator.getDatabaseVersion(),
+    await postgrator.getMaxVersion()
+  )
+
+  await postgrator.migrate()
+
+  console.log('Migrated DB schema to version', await postgrator.getDatabaseVersion())
+}

--- a/lib/migrate.js
+++ b/lib/migrate.js
@@ -1,3 +1,4 @@
+import pg from 'pg'
 import Postgrator from 'postgrator'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
@@ -8,7 +9,23 @@ const migrationsDirectory = join(
   'migrations'
 )
 
-export const migrate = async (client) => {
+/**
+ *@param {pg.Config} pgConfig
+ */
+export const migrateWithPgConfig = async (pgConfig) => {
+  const client = new pg.Client(pgConfig)
+  await client.connect()
+  try {
+    await migrateWithPgClient(client)
+  } finally {
+    await client.end()
+  }
+}
+
+/**
+ * @param {pg.Client} client
+ */
+export const migrateWithPgClient = async (client) => {
   const postgrator = new Postgrator({
     migrationPattern: join(migrationsDirectory, '*'),
     driver: 'pg',

--- a/lib/public-stats.js
+++ b/lib/public-stats.js
@@ -1,0 +1,38 @@
+import createDebug from 'debug'
+import pg from 'pg'
+import { DATABASE_URL } from './config.js'
+
+const debug = createDebug('spark:public-stats')
+
+/**
+ * @param {import('./preprocess').Measurement[]} measurements
+ */
+export const updatePublicStats = async (measurements) => {
+  let total = 0
+  let successful = 0
+  for (const m of measurements) {
+    total++
+    // TODO: take into account fraud detection
+    if (m.retrievalResult === 'OK') successful++
+  }
+
+  debug('Updating public retrieval stats: total += %s successful += %s', total, successful)
+  const pgClient = new pg.Client({ connectionString: DATABASE_URL })
+  await pgClient.connect()
+  try {
+    await pgClient.query(`
+    INSERT INTO retrievals
+      (day, total, successful)
+    VALUES
+      (now(), $1, $2)
+    ON CONFLICT(day) DO UPDATE SET
+      total = retrievals.total + $1,
+      successful = retrievals.total + $2
+  `, [
+      total,
+      successful
+    ])
+  } finally {
+    await pgClient.end()
+  }
+}

--- a/lib/public-stats.js
+++ b/lib/public-stats.js
@@ -21,13 +21,13 @@ export const updatePublicStats = async (measurements) => {
   await pgClient.connect()
   try {
     await pgClient.query(`
-    INSERT INTO retrievals
+    INSERT INTO retrieval_stats
       (day, total, successful)
     VALUES
       (now(), $1, $2)
     ON CONFLICT(day) DO UPDATE SET
-      total = retrievals.total + $1,
-      successful = retrievals.total + $2
+      total = retrieval_stats.total + $1,
+      successful = retrieval_stats.total + $2
   `, [
       total,
       successful

--- a/lib/public-stats.js
+++ b/lib/public-stats.js
@@ -1,13 +1,13 @@
 import createDebug from 'debug'
-import pg from 'pg'
-import { DATABASE_URL } from './config.js'
 
 const debug = createDebug('spark:public-stats')
 
 /**
- * @param {import('./preprocess').Measurement[]} measurements
+ * @param {object} args
+ * @param {import('./typings').CreatePgClient} args.createPgClient
+ * @param {import('./preprocess').Measurement[]} args.measurements
  */
-export const updatePublicStats = async (measurements) => {
+export const updatePublicStats = async ({ createPgClient, measurements }) => {
   let total = 0
   let successful = 0
   for (const m of measurements) {
@@ -17,8 +17,7 @@ export const updatePublicStats = async (measurements) => {
   }
 
   debug('Updating public retrieval stats: total += %s successful += %s', total, successful)
-  const pgClient = new pg.Client({ connectionString: DATABASE_URL })
-  await pgClient.connect()
+  const pgClient = await createPgClient()
   try {
     await pgClient.query(`
     INSERT INTO retrieval_stats

--- a/lib/typings.d.ts
+++ b/lib/typings.d.ts
@@ -76,3 +76,5 @@ export interface GroupWinningStats {
 export interface FraudDetectionStats {
   groupWinning: GroupWinningStats
 }
+
+export type CreatePgClient = () => Promise<import('pg').Client>;

--- a/migrations/001.do.retrieval-stats.sql
+++ b/migrations/001.do.retrieval-stats.sql
@@ -1,0 +1,5 @@
+CREATE TABLE retrievals (
+  day DATE NOT NULL PRIMARY KEY,
+  total INT NOT NULL,
+  successful INT NOT NULL
+);

--- a/migrations/001.do.retrieval-stats.sql
+++ b/migrations/001.do.retrieval-stats.sql
@@ -1,4 +1,4 @@
-CREATE TABLE retrievals (
+CREATE TABLE retrieval_stats (
   day DATE NOT NULL PRIMARY KEY,
   total INT NOT NULL,
   successful INT NOT NULL

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,12 @@
         "ethers": "^5.7.2",
         "ipfs-car": "^1.1.0",
         "ipfs-unixfs-exporter": "^13.2.5",
-        "just-percentile": "^4.2.0"
+        "just-percentile": "^4.2.0",
+        "pg": "^8.11.3",
+        "postgrator": "^7.2.0"
       },
       "devDependencies": {
         "mocha": "^10.2.0",
-        "pg": "^8.11.3",
         "standard": "^17.1.0"
       }
     },
@@ -1453,8 +1454,7 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1534,7 +1534,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1598,7 +1597,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
       "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -1749,8 +1747,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -2633,8 +2630,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2739,7 +2735,6 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3028,7 +3023,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3906,7 +3900,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4221,7 +4214,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -4322,8 +4314,7 @@
     "node_modules/packet-reader": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
-      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
-      "dev": true
+      "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -4363,7 +4354,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4387,7 +4377,6 @@
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
       "integrity": "sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==",
-      "dev": true,
       "dependencies": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",
@@ -4416,20 +4405,17 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
       "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
-      "dev": true,
       "optional": true
     },
     "node_modules/pg-connection-string": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
-      "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==",
-      "dev": true
+      "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA=="
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
-      "dev": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -4438,7 +4424,6 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
       "integrity": "sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==",
-      "dev": true,
       "peerDependencies": {
         "pg": ">=8.0"
       }
@@ -4446,14 +4431,12 @@
     "node_modules/pg-protocol": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
-      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q==",
-      "dev": true
+      "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q=="
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-      "dev": true,
       "dependencies": {
         "pg-int8": "1.0.1",
         "postgres-array": "~2.0.0",
@@ -4469,7 +4452,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
       "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
-      "dev": true,
       "dependencies": {
         "split2": "^4.1.0"
       }
@@ -4569,11 +4551,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/postgrator": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/postgrator/-/postgrator-7.2.0.tgz",
+      "integrity": "sha512-rVi/X5//51Sj5SWsBb2knBn/GCWdFOXRdq4VATnNePLK1h2774j0byr5tsDDb5B+UWVAZftjq5VYCQaB6dXMWw==",
+      "dependencies": {
+        "glob": "^7.2.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/postgres-array": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -4582,7 +4574,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
       "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4591,7 +4582,6 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4600,7 +4590,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-      "dev": true,
       "dependencies": {
         "xtend": "^4.0.0"
       },
@@ -4998,7 +4987,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-      "dev": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -5532,8 +5520,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
       "version": "7.4.6",
@@ -5568,7 +5555,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4"
       }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "type": "module",
   "scripts": {
+    "migrate": "node bin/migrate.js",
     "start": "node bin/spark-evaluate.js",
     "test": "standard && mocha"
   },
   "devDependencies": {
     "mocha": "^10.2.0",
-    "pg": "^8.11.3",
     "standard": "^17.1.0"
   },
   "dependencies": {
@@ -19,7 +19,9 @@
     "ethers": "^5.7.2",
     "ipfs-car": "^1.1.0",
     "ipfs-unixfs-exporter": "^13.2.5",
-    "just-percentile": "^4.2.0"
+    "just-percentile": "^4.2.0",
+    "pg": "^8.11.3",
+    "postgrator": "^7.2.0"
   },
   "standard": {
     "env": [

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -34,7 +34,7 @@ describe('evaluate', () => {
   })
 
   beforeEach(async () => {
-    await pgClient.query('DELETE FROM retrievals')
+    await pgClient.query('DELETE FROM retrieval_stats')
   })
 
   after(async () => {
@@ -78,7 +78,7 @@ describe('evaluate', () => {
     assertPointFieldValue(point, 'total_nodes', '1i')
     // TODO: assert more point fields
 
-    const { rows: publicStats } = await pgClient.query('SELECT * FROM retrievals')
+    const { rows: publicStats } = await pgClient.query('SELECT * FROM retrieval_stats')
     assert.deepStrictEqual(publicStats, [{
       day: today(),
       total: 10,

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -9,7 +9,7 @@ import { RoundData } from '../lib/round.js'
 import { DATABASE_URL } from '../lib/config.js'
 import pg from 'pg'
 import { beforeEach } from 'mocha'
-import { migrate } from '../lib/migrate.js'
+import { migrateWithPgClient } from '../lib/migrate.js'
 
 const { BigNumber } = ethers
 
@@ -30,7 +30,7 @@ describe('evaluate', () => {
   before(async () => {
     pgClient = new pg.Client({ connectionString: DATABASE_URL })
     await pgClient.connect()
-    await migrate(pgClient)
+    await migrateWithPgClient(pgClient)
   })
 
   beforeEach(async () => {

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -25,11 +25,16 @@ const recordTelemetry = (measurementName, fn) => {
 }
 beforeEach(() => telemetry.splice(0))
 
+const createPgClient = async () => {
+  const pgClient = new pg.Client({ connectionString: DATABASE_URL })
+  await pgClient.connect()
+  return pgClient
+}
+
 describe('evaluate', () => {
   let pgClient
   before(async () => {
-    pgClient = new pg.Client({ connectionString: DATABASE_URL })
-    await pgClient.connect()
+    pgClient = await createPgClient()
     await migrateWithPgClient(pgClient)
   })
 
@@ -60,6 +65,7 @@ describe('evaluate', () => {
       ieContractWithSigner,
       fetchRoundDetails,
       recordTelemetry,
+      createPgClient,
       logger
     })
     assert.deepStrictEqual(rounds, {})
@@ -102,6 +108,7 @@ describe('evaluate', () => {
       ieContractWithSigner,
       fetchRoundDetails,
       recordTelemetry,
+      createPgClient,
       logger
     })
     assert.strictEqual(setScoresCalls.length, 1)
@@ -150,6 +157,7 @@ describe('evaluate', () => {
       ieContractWithSigner,
       fetchRoundDetails,
       recordTelemetry,
+      createPgClient,
       logger
     })
     assert.strictEqual(setScoresCalls.length, 1)
@@ -189,6 +197,7 @@ describe('evaluate', () => {
       ieContractWithSigner,
       recordTelemetry,
       fetchRoundDetails,
+      createPgClient,
       logger
     })
     assert.strictEqual(setScoresCalls.length, 1)
@@ -234,6 +243,7 @@ describe('evaluate', () => {
       ieContractWithSigner,
       recordTelemetry,
       fetchRoundDetails,
+      createPgClient,
       logger
     })
     assert.strictEqual(setScoresCalls.length, 1)
@@ -272,6 +282,7 @@ describe('evaluate', () => {
       ieContractWithSigner,
       recordTelemetry,
       fetchRoundDetails,
+      createPgClient,
       logger
     })
 

--- a/test/helpers/test-data.js
+++ b/test/helpers/test-data.js
@@ -30,3 +30,12 @@ export const VALID_MEASUREMENT = {
 // we freeze this test data object. If we forget to clone this default measurement
 // then such test will immediately fail.
 Object.freeze(VALID_MEASUREMENT)
+
+export const today = () => {
+  const d = new Date()
+  d.setHours(0)
+  d.setMinutes(0)
+  d.setSeconds(0)
+  d.setMilliseconds(0)
+  return d
+}


### PR DESCRIPTION
A prototype implementing code for producing stats to power our Spark Public Dashboard. Design doc: 
https://pl-strflt.notion.site/DB-for-SPARK-public-data-a79cbb7a0ff5447980b714afdb2645d6

1. Add a runtime dependency on a PG database, using a new database
   name `spark_stats` (originally: ~~`spark_public`~~). Setup database schema migrations executed
   at service startup.

2. Define the first table `retrievals` to keep stats about all vs
   succesfull retrievals performed each day.

3. Update the evaluate step to update these stats for each round
   completed.

**TODO**

- [x] Setup PG DB for GitHub Actions to make the tests pass
- [x] Create a new PG user `spark_evaluate` and a new database `spark_stats`
- [x] Define DATABASE_URL in Fly.io secrets

Links:
- https://github.com/filecoin-station/roadmap/issues/57