### PR TITLE
fix: handle failure of ieContract.setScores()

### DIFF
--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -133,18 +133,33 @@ export const evaluate = async ({
   const start = new Date()
   const buckets = createSetScoresBuckets(participants)
   for (const [bucketIndex, bucket] of Object.entries(buckets)) {
-    const tx = await ieContractWithSigner.setScores(
-      roundIndex,
-      bucket.participants,
-      bucket.scores
-    )
-    logger.log(
-      'EVALUATE ROUND %s: IE.setScores() TX hash: %s CALL: %s/%s',
-      roundIndex,
-      tx.hash,
-      bucketIndex + 1,
-      buckets.length
-    )
+    try {
+      const tx = await ieContractWithSigner.setScores(
+        roundIndex,
+        bucket.participants,
+        bucket.scores
+      )
+      logger.log(
+        'EVALUATE ROUND %s: IE.setScores() TX hash: %s CALL: %s/%s',
+        roundIndex,
+        tx.hash,
+        bucketIndex + 1,
+        buckets.length
+      )
+    } catch (err) {
+      logger.error('CANNOT SUBMIT SCORES FOR ROUND %S (CALL %s/%s): %s',
+        roundIndex,
+        bucketIndex + 1,
+        buckets.length
+      )
+      Sentry.captureException(err, {
+        extras: {
+          roundIndex,
+          bucketIndex: bucketIndex + 1,
+          bucketCount: buckets.length
+        }
+      })
+    }
   }
   const setScoresDuration = new Date() - start
 


### PR DESCRIPTION
When the smart contract call fails, report the error and keep going.  This error is not recoverable, but we need to report metrics and clean up the round data.
