### PR TITLE
fix: calculate RSR using honest measurements only

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -3,7 +3,7 @@ const {
   // FIXME Add back chain.love either when it's online or once onContractEvent
   // supports rpc failover
   // RPC_URLS = 'https://api.node.glif.io/rpc/v0,https://api.chain.love/rpc/v1',
-  RPC_URLS = 'https://api.node.glif.io/rpc/v0'
+  RPC_URLS = 'https://api.node.glif.io/rpc/v0',
   GLIF_TOKEN,
   DATABASE_URL = 'postgres://localhost:5432/spark_stats',
   SPARK_API = 'https://api.filspark.com'

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -226,7 +226,7 @@ export const evaluate = async ({
   }
 
   try {
-    await updatePublicStats({ createPgClient, measurements })
+    await updatePublicStats({ createPgClient, honestMeasurements })
   } catch (err) {
     console.error('Cannot update public stats.', err)
     Sentry.captureException(err)

--- a/lib/public-stats.js
+++ b/lib/public-stats.js
@@ -5,12 +5,12 @@ const debug = createDebug('spark:public-stats')
 /**
  * @param {object} args
  * @param {import('./typings').CreatePgClient} args.createPgClient
- * @param {import('./preprocess').Measurement[]} args.measurements
+ * @param {import('./preprocess').Measurement[]} args.honestMeasurements
  */
-export const updatePublicStats = async ({ createPgClient, measurements }) => {
+export const updatePublicStats = async ({ createPgClient, honestMeasurements }) => {
   let total = 0
   let successful = 0
-  for (const m of measurements) {
+  for (const m of honestMeasurements) {
     total++
     // TODO: take into account fraud detection
     if (m.retrievalResult === 'OK') successful++

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -84,8 +84,8 @@ describe('evaluate', () => {
     const { rows: publicStats } = await pgClient.query('SELECT * FROM retrieval_stats')
     assert.deepStrictEqual(publicStats, [{
       day: today(),
-      total: 10,
-      successful: 10
+      total: 1,
+      successful: 1
     }])
   })
 


### PR DESCRIPTION
Based on our live discussion, we want to calculate the Retrieval Success Rate from measurements that passed fraud detection.

Links:
- https://github.com/filecoin-station/roadmap/issues/57
