### PR TITLE
feat: report daily participants to public stats

### DIFF
--- a/lib/public-stats.js
+++ b/lib/public-stats.js
@@ -21,14 +21,14 @@ export const updatePublicStats = async ({ createPgClient, honestMeasurements }) 
   const pgClient = await createPgClient()
   try {
     await updateRetrievalStats(pgClient, retrievalStats)
-    await updateDailyParticipants(pgClient, Array.from(participants.values()))
+    await updateDailyParticipants(pgClient, participants)
   } finally {
     await pgClient.end()
   }
 }
 
 /**
- * @param {import('./typings').CreatePgClient} createPgClient
+ * @param {import('pg').Client} pgClient
  * @param {object} stats
  * @param {number} stats.total
  * @param {number} stats.successful
@@ -50,42 +50,80 @@ const updateRetrievalStats = async (pgClient, { total, successful }) => {
 }
 
 /**
- * @param {import('./typings').CreatePgClient} createPgClient
- * @param {string[]} participants
+ * @param {import('pg').Client} pgClient
+ * @param {Set<string>} participants
  */
-const updateDailyParticipants = async (pgClient, participants) => {
-  debug('Updating daily participants (%s seen)', participants.length)
-  for (const participantAddress of participants) {
-    const participantId = await mapParticipantToId(pgClient, participantAddress)
-    await pgClient.query(`
-      INSERT INTO daily_participants
-        (day, participant_id)
-      VALUES
-        (now(), $1)
-      ON CONFLICT DO NOTHING
-    `, [
-      participantId
-    ])
-  }
+export const updateDailyParticipants = async (pgClient, participants) => {
+  debug('Updating daily participants, count=%s', participants.size)
+  const ids = await mapParticipantsToIds(pgClient, participants)
+  await pgClient.query(`
+    INSERT INTO daily_participants (day, participant_id)
+    SELECT now() as day, UNNEST($1::INT[]) AS participant_id
+    ON CONFLICT DO NOTHING
+  `, [
+    ids
+  ])
 }
 
 /**
- * @param {import('./typings').CreatePgClient} createPgClient
- * @param {string} participantAddress
+ * @param {import('pg').Client} pgClient
+ * @param {Set<string>} participantsSet
+ * @returns {Promise<string[]>} A list of participant ids. The order of ids is not defined.
  */
-const mapParticipantToId = async (pgClient, participantAddress) => {
-  const { rows } = await pgClient.query(`
-    INSERT INTO participants (participant_address) VALUES ($1)
+export const mapParticipantsToIds = async (pgClient, participantsSet) => {
+  debug('Mapping participants to id, count=%s', participantsSet.size)
+
+  /** @type {string[]} */
+  const ids = []
+
+  // TODO: We can further optimise performance of this function by using
+  // an in-memory LRU cache. Our network has currently ~2k participants,
+  // we need ~50 bytes for each (address, id) pair, that's only ~100KB of data.
+
+  // TODO: passing the entire list of participants as a single query parameter
+  // will probably not scale beyond several thousands of addresses. We will
+  // need to rework the queries to split large arrays into smaller batches.
+
+  // In most rounds, we have already seen most of the participant addresses
+  // If we use "INSERT...ON CONFLICT", then PG increments id counter even for
+  // existing addresses where we end up skipping the insert. This could quickly
+  // exhaust the space of all 32bit integers.
+  // Solution: query the table for know records before running the insert.
+  //
+  // Caveat: In my testing, this query was not able to leverage the (unique)
+  // index on participants.participant_address and performed a full table scan
+  // after the array grew past ~10 items. If this becomes a problem, we can
+  // introduce the LRU cache mentioned above.
+  const { rows: found } = await pgClient.query(
+    'SELECT * FROM participants WHERE participant_address = ANY($1::TEXT[])',
+    [Array.from(participantsSet.values())]
+  )
+  debug('Known participants count=%s', found.length)
+
+  // eslint-disable-next-line camelcase
+  for (const { id, participant_address } of found) {
+    ids.push(id)
+    participantsSet.delete(participant_address)
+  }
+
+  debug('New participant addresses count=%s', participantsSet.size)
+
+  // Register the new addresses. Use "INSERT...ON CONFLICT" to handle the race condition
+  // where another client may have registered these addresses between our previous
+  // SELECT query and the next INSERT query.
+  const newAddresses = Array.from(participantsSet.values())
+  debug('Registering new participant addresses, count=%s', newAddresses.length)
+  const { rows: created } = await pgClient.query(`
+    INSERT INTO participants (participant_address)
+    SELECT UNNEST($1::TEXT[]) AS participant_address
     ON CONFLICT(participant_address) DO UPDATE
       -- this no-op update is needed to populate "RETURNING id"
       SET participant_address = EXCLUDED.participant_address
     RETURNING id
   `, [
-    participantAddress
+    newAddresses
   ])
 
-  assert.strictEqual(rows.length, 1)
-  const { id } = rows[0]
-  assert.strictEqual(typeof id, 'number')
-  return id
+  assert.strictEqual(created.length, newAddresses.length)
+  return ids.concat(created.map(r => r.id))
 }

--- a/lib/public-stats.js
+++ b/lib/public-stats.js
@@ -1,3 +1,4 @@
+import assert from 'node:assert'
 import createDebug from 'debug'
 
 const debug = createDebug('spark:public-stats')
@@ -8,18 +9,33 @@ const debug = createDebug('spark:public-stats')
  * @param {import('./preprocess').Measurement[]} args.honestMeasurements
  */
 export const updatePublicStats = async ({ createPgClient, honestMeasurements }) => {
-  let total = 0
-  let successful = 0
+  const retrievalStats = { total: 0, successful: 0 }
+  const participants = new Set()
   for (const m of honestMeasurements) {
-    total++
-    // TODO: take into account fraud detection
-    if (m.retrievalResult === 'OK') successful++
+    retrievalStats.total++
+    if (m.retrievalResult === 'OK') retrievalStats.successful++
+
+    participants.add(m.participantAddress)
   }
 
-  debug('Updating public retrieval stats: total += %s successful += %s', total, successful)
   const pgClient = await createPgClient()
   try {
-    await pgClient.query(`
+    await updateRetrievalStats(pgClient, retrievalStats)
+    await updateDailyParticipants(pgClient, Array.from(participants.values()))
+  } finally {
+    await pgClient.end()
+  }
+}
+
+/**
+ * @param {import('./typings').CreatePgClient} createPgClient
+ * @param {object} stats
+ * @param {number} stats.total
+ * @param {number} stats.successful
+ */
+const updateRetrievalStats = async (pgClient, { total, successful }) => {
+  debug('Updating public retrieval stats: total += %s successful += %s', total, successful)
+  await pgClient.query(`
     INSERT INTO retrieval_stats
       (day, total, successful)
     VALUES
@@ -28,10 +44,48 @@ export const updatePublicStats = async ({ createPgClient, honestMeasurements }) 
       total = retrieval_stats.total + $1,
       successful = retrieval_stats.successful + $2
   `, [
-      total,
-      successful
+    total,
+    successful
+  ])
+}
+
+/**
+ * @param {import('./typings').CreatePgClient} createPgClient
+ * @param {string[]} participants
+ */
+const updateDailyParticipants = async (pgClient, participants) => {
+  debug('Updating daily participants (%s seen)', participants.length)
+  for (const participantAddress of participants) {
+    const participantId = await mapParticipantToId(pgClient, participantAddress)
+    await pgClient.query(`
+      INSERT INTO daily_participants
+        (day, participant_id)
+      VALUES
+        (now(), $1)
+      ON CONFLICT DO NOTHING
+    `, [
+      participantId
     ])
-  } finally {
-    await pgClient.end()
   }
+}
+
+/**
+ * @param {import('./typings').CreatePgClient} createPgClient
+ * @param {string} participantAddress
+ */
+const mapParticipantToId = async (pgClient, participantAddress) => {
+  const { rows } = await pgClient.query(`
+    INSERT INTO participants (participant_address) VALUES ($1)
+    ON CONFLICT(participant_address) DO UPDATE
+      -- this no-op update is needed to populate "RETURNING id"
+      SET participant_address = EXCLUDED.participant_address
+    RETURNING id
+  `, [
+    participantAddress
+  ])
+
+  assert.strictEqual(rows.length, 1)
+  const { id } = rows[0]
+  assert.strictEqual(typeof id, 'number')
+  return id
 }

--- a/migrations/003.do.daily-participants.sql
+++ b/migrations/003.do.daily-participants.sql
@@ -1,0 +1,11 @@
+CREATE TABLE participants (
+  id SERIAL NOT NULL PRIMARY KEY,
+  participant_address TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE daily_participants (
+  day DATE NOT NULL,
+  participant_id INTEGER NOT NULL REFERENCES participants(id),
+  PRIMARY KEY (day, participant_id)
+);
+CREATE INDEX daily_participants_day ON daily_participants (day);

--- a/test/public-stats.test.js
+++ b/test/public-stats.test.js
@@ -4,7 +4,8 @@ import pg from 'pg'
 import { DATABASE_URL } from '../lib/config.js'
 import { migrateWithPgClient } from '../lib/migrate.js'
 import { VALID_MEASUREMENT } from './helpers/test-data.js'
-import { updatePublicStats } from '../lib/public-stats.js'
+import { mapParticipantsToIds, updateDailyParticipants, updatePublicStats } from '../lib/public-stats.js'
+import { beforeEach } from 'mocha'
 
 const createPgClient = async () => {
   const pgClient = new pg.Client({ connectionString: DATABASE_URL })
@@ -19,12 +20,19 @@ describe('public-stats', () => {
     await migrateWithPgClient(pgClient)
   })
 
+  let today
   beforeEach(async () => {
     await pgClient.query('DELETE FROM retrieval_stats')
+    await pgClient.query('DELETE FROM daily_participants')
+    // empty `participants` table in such way that the next participants.id will be always 1
+    await pgClient.query('TRUNCATE TABLE participants RESTART IDENTITY CASCADE')
+
     // Run all tests inside a transaction to ensure `now()` always returns the same value
     // See https://dba.stackexchange.com/a/63549/125312
     // This avoids subtle race conditions when the tests are executed around midnight.
     await pgClient.query('BEGIN TRANSACTION')
+
+    today = await getCurrentDate()
   })
 
   afterEach(async () => {
@@ -37,8 +45,6 @@ describe('public-stats', () => {
 
   describe('retrieval_stats', () => {
     it('creates or updates the row for today', async () => {
-      const { rows: [{ today }] } = await pgClient.query('SELECT now()::DATE::TEXT as today')
-
       /** @type {import('../lib/preprocess').Measurement[]} */
       const honestMeasurements = [
         { ...VALID_MEASUREMENT, retrievalResult: 'OK' },
@@ -64,4 +70,74 @@ describe('public-stats', () => {
       ])
     })
   })
+
+  describe('daily_participants', () => {
+    it('submits daily_participants data for today', async () => {
+      /** @type {import('../lib/preprocess').Measurement[]} */
+      const honestMeasurements = [
+        { ...VALID_MEASUREMENT, participantAddress: '0x10' },
+        { ...VALID_MEASUREMENT, participantAddress: '0x10' },
+        { ...VALID_MEASUREMENT, participantAddress: '0x20' }
+      ]
+      await updatePublicStats({ createPgClient, honestMeasurements })
+
+      const { rows } = await pgClient.query(
+        'SELECT day::TEXT, participant_id FROM daily_participants'
+      )
+      assert.deepStrictEqual(rows, [
+        { day: today, participant_id: 1 },
+        { day: today, participant_id: 2 }
+      ])
+    })
+
+    it('creates a new daily_participants row', async () => {
+      await updateDailyParticipants(pgClient, new Set(['0x10', '0x20']))
+
+      const { rows: created } = await pgClient.query(
+        'SELECT day::TEXT, participant_id FROM daily_participants'
+      )
+      assert.deepStrictEqual(created, [
+        { day: today, participant_id: 1 },
+        { day: today, participant_id: 2 }
+      ])
+    })
+
+    it('handles participants already seen today', async () => {
+      await updateDailyParticipants(pgClient, new Set(['0x10', '0x20']))
+      await updateDailyParticipants(pgClient, new Set(['0x10', '0x30', '0x20']))
+
+      const { rows: created } = await pgClient.query(
+        'SELECT day::TEXT, participant_id FROM daily_participants'
+      )
+      assert.deepStrictEqual(created, [
+        { day: today, participant_id: 1 },
+        { day: today, participant_id: 2 },
+        { day: today, participant_id: 3 }
+      ])
+    })
+
+    it('maps new participant addresses to new ids', async () => {
+      const ids = await mapParticipantsToIds(pgClient, new Set(['0x10', '0x20']))
+      ids.sort()
+      assert.deepStrictEqual(ids, [1, 2])
+    })
+
+    it('maps existing participants to their existing ids', async () => {
+      const participants = new Set(['0x10', '0x20'])
+      const first = await mapParticipantsToIds(pgClient, participants)
+      first.sort()
+      assert.deepStrictEqual(first, [1, 2])
+
+      participants.add('0x30')
+      participants.add('0x40')
+      const second = await mapParticipantsToIds(pgClient, participants)
+      second.sort()
+      assert.deepStrictEqual(second, [1, 2, 3, 4])
+    })
+  })
+
+  const getCurrentDate = async () => {
+    const { rows: [{ today }] } = await pgClient.query('SELECT now()::DATE::TEXT as today')
+    return today
+  }
 })


### PR DESCRIPTION
Create a new `spark_stats` table to keep track of daily participants:

```sql
SELECT day::TEXT, COUNT(DISTINCT participant_id) as count
FROM daily_participants GROUP BY day;
```

This table allows us to correctly calculate monthly participants too:

```sql
SELECT
  date_trunc('month', day)::DATE::TEXT as month,
  COUNT(DISTINCT participant_id) as count
FROM daily_participants
GROUP BY month;
```

TODO:
- [x] add tests

Links:
- https://github.com/filecoin-station/spark-evaluate/issues/79