### PR TITLE
feat: new stat `rate_tasks_advertising_http`

### DIFF
--- a/lib/retrieval-stats.js
+++ b/lib/retrieval-stats.js
@@ -21,6 +21,11 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
 
   const uniqueTasksCount = countUniqueTasks(measurements)
 
+  /** @type {Set<string>} */
+  const tasksAdvertisingHttp = new Set()
+  /** @type {Set<string>} */
+  const tasksQueryingIndexer = new Set()
+
   // Calculate aggregates per retrieval result
 
   // We are intentionally not initializing all possible keys here.
@@ -83,6 +88,10 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
 
     const node = `${m.inet_group}::${m.participantAddress}`
     tasksPerNode.set(node, (tasksPerNode.get(node) ?? 0) + 1)
+
+    const taskId = getTaskId(m)
+    if (m.indexerResult) tasksQueryingIndexer.add(taskId)
+    if (m.indexerResult === 'OK') tasksAdvertisingHttp.add(taskId)
   }
   const successRate = resultBreakdown.OK / totalCount
 
@@ -109,6 +118,11 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
   for (const [result, count] of Object.entries(indexerResultBreakdown)) {
     telemetryPoint.floatField(`indexer_rate_${result}`, count / totalCount)
   }
+
+  telemetryPoint.floatField('rate_tasks_advertising_http', tasksQueryingIndexer.size > 0
+    ? tasksAdvertisingHttp.size / tasksQueryingIndexer.size
+    : 0
+  )
 }
 
 /**
@@ -137,14 +151,14 @@ const addHistogramToPoint = (point, values, fieldNamePrefix = '') => {
   }
 }
 
+// TODO: include Filecoin Deal id
+const getTaskId = (/** @type {import('./typings').Measurement} */m) => `${m.cid}`
+
 /**
  * @param {import('./typings').Measurement[]} measurements
  * @returns {number}
  */
 const countUniqueTasks = (measurements) => {
-  // TODO: include Filecoin Deal id
-  const getTaskId = (/** @type {import('./typings').Measurement} */m) => `${m.cid}`
-
   const uniqueTasks = new Set()
   for (const m of measurements) {
     const id = getTaskId(m)
@@ -167,8 +181,7 @@ export const recordCommitteeSizes = (measurements, point) => {
    * }>} */
   const tasks = new Map()
   for (const m of measurements) {
-    // TODO: include Filecoin Deal id
-    const key = `${m.cid}`
+    const key = getTaskId(m)
     let data = tasks.get(key)
     if (!data) {
       data = {

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -31,9 +31,10 @@ describe('retrieval statistics', () => {
       },
       {
         ...VALID_MEASUREMENT,
+        cid: 'bafyanother',
         carTooLarge: true,
         retrievalResult: 'CAR_TOO_LARGE',
-        indexerResult: 'ERROR_404',
+        indexerResult: undefined,
         byte_length: 200 * 1024 * 1024
       },
       {
@@ -61,7 +62,7 @@ describe('retrieval statistics', () => {
     debug('stats', point.fields)
 
     assertPointFieldValue(point, 'measurements', '4i')
-    assertPointFieldValue(point, 'unique_tasks', '2i')
+    assertPointFieldValue(point, 'unique_tasks', '3i')
     assertPointFieldValue(point, 'success_rate', '0.25')
     assertPointFieldValue(point, 'participants', '2i')
     assertPointFieldValue(point, 'inet_groups', '2i')
@@ -91,9 +92,14 @@ describe('retrieval statistics', () => {
     assertPointFieldValue(point, 'tasks_per_node_p95', '2i')
 
     assertPointFieldValue(point, 'indexer_rate_OK', '0.25')
-    assertPointFieldValue(point, 'indexer_rate_ERROR_404', '0.25')
+    assertPointFieldValue(point, 'indexer_rate_UNDEFINED', '0.25')
     assertPointFieldValue(point, 'indexer_rate_HTTP_NOT_ADVERTISED', '0.25')
     assertPointFieldValue(point, 'indexer_rate_NO_VALID_ADVERTISEMENT', '0.25')
+
+    // There are three unique tasks in our measurements, but one of the task does not have
+    // any measurement with indexer result. From the two remaining tasks, only one of them
+    // has a measurement reporting that HTTP retrieval was advertised to IPNI
+    assertPointFieldValue(point, 'rate_tasks_advertising_http', '0.5')
   })
 
   it('handles first_byte_at set to unix epoch', () => {


### PR DESCRIPTION
Calculate the ratio of tasks where at least one measurement reported that HTTP retrieval was advertised to IPNI vs the number of tasks where at least measurement reported `indexerResult`.

This is a follow-up for https://github.com/filecoin-station/spark-evaluate/pull/144 which calculates the indexer result breakdown from all measurements, including measurements
submited by outdated Spark checkers that don't query IPNI at all.

Links:
- https://www.notion.so/pl-strflt/Moving-IPNI-queries-to-Spark-checkers-c58175c0f1c841e6bb82ac44a1472a98
- https://github.com/filecoin-station/spark/issues/40

