### PR TITLE
feat: include minerId in task definition

### DIFF
--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -257,8 +257,9 @@ export const runFraudDetection = async (roundIndex, measurements, sparkRoundDeta
     assert(typeof m.inet_group === 'string', 'missing inet_group')
     assert(typeof m.finished_at === 'number', 'missing finished_at')
 
-    // TODO: check also Filecoin Deal id
-    const isValidTask = sparkRoundDetails.retrievalTasks.some(t => t.cid === m.cid)
+    const isValidTask = sparkRoundDetails.retrievalTasks.some(
+      t => t.cid === m.cid && t.minerId === m.minerId
+    )
     if (!isValidTask) {
       m.fraudAssessment = 'INVALID_TASK'
     }
@@ -272,8 +273,7 @@ export const runFraudDetection = async (roundIndex, measurements, sparkRoundDeta
   for (const m of measurements) {
     if (m.fraudAssessment) continue
 
-    // TODO: include Filecoin Deal id
-    const key = `${m.inet_group}::${m.cid}`
+    const key = `${m.inet_group}::${m.cid}::${m.minerId}`
     let group = taskGroups.get(key)
     if (!group) {
       group = []
@@ -341,10 +341,11 @@ export const runFraudDetection = async (roundIndex, measurements, sparkRoundDeta
       // Print round & participant address & CID together to simplify lookup when debugging
       // Omit the `m` object from the format string to get nicer formatting
       debug(
-        'FRAUD ASSESSMENT for round=%s client=%s cid=%s',
+        'FRAUD ASSESSMENT for round=%s client=%s cid=%s minerId=%s',
         roundIndex,
         m.participantAddress,
         m.cid,
+        m.minerId,
         m)
     }
   }
@@ -370,9 +371,10 @@ const calculateInetGroupSuccessRates = (taskGroups) => {
 
   for (const groupMeasurements of taskGroups.values()) {
     debug(
-      '  measurements for inet_group=%s cid=%s',
+      '  measurements for inet_group=%s cid=%s minerId=%s',
       groupMeasurements[0].inet_group,
-      groupMeasurements[0].cid
+      groupMeasurements[0].cid,
+      groupMeasurements[0].minerId
     )
     // First, find participants that submitted some valid measurements for this task
     // and find out whether they were rewarded or not

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -15,6 +15,7 @@ export class Measurement {
     this.retrievalResult = pointerize(getRetrievalResult(m))
     this.cid = pointerize(m.cid)
     this.minerId = pointerize(m.miner_id)
+    // Note: providerId is recorded by spark-publish but we don't use it for evaluations yet
     this.providerId = pointerize(m.provider_id)
     this.spark_version = pointerize(m.spark_version)
     this.fraudAssessment = null

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -14,6 +14,8 @@ export class Measurement {
     this.participantAddress = pointerize(parseParticipantAddress(m.participant_address))
     this.retrievalResult = pointerize(getRetrievalResult(m))
     this.cid = pointerize(m.cid)
+    this.minerId = pointerize(m.miner_id)
+    this.providerId = pointerize(m.provider_id)
     this.spark_version = pointerize(m.spark_version)
     this.fraudAssessment = null
     this.inet_group = pointerize(m.inet_group)
@@ -73,10 +75,11 @@ export const preprocess = async ({
       // Print round & participant address & CID together to simplify lookup when debugging
       // Omit the `m` object from the format string to get nicer formatting
       debug(
-        'RETRIEVAL RESULT for round=%s client=%s cid=%s: %s',
+        'RETRIEVAL RESULT for round=%s client=%s cid=%s minerId=%s: %s',
         roundIndex,
         measurement.participantAddress,
         measurement.cid,
+        measurement.minerId,
         measurement.retrievalResult,
         measurement)
 

--- a/lib/retrieval-stats.js
+++ b/lib/retrieval-stats.js
@@ -151,8 +151,7 @@ const addHistogramToPoint = (point, values, fieldNamePrefix = '') => {
   }
 }
 
-// TODO: include Filecoin Deal id
-export const getTaskId = (/** @type {import('./typings').Measurement} */m) => `${m.cid}`
+export const getTaskId = (/** @type {import('./typings').Measurement} */m) => `${m.cid}::${m.minerId}`
 
 /**
  * @param {import('./typings').Measurement[]} measurements

--- a/lib/typings.d.ts
+++ b/lib/typings.d.ts
@@ -10,8 +10,7 @@ export {
  */
 export interface RetrievalTask {
   cid: String;
-  providerAddress: String;
-  protocol: String;
+  minerId: String;
 }
 
 /**

--- a/test/helpers/test-data.js
+++ b/test/helpers/test-data.js
@@ -1,12 +1,5 @@
 export const VALID_PARTICIPANT_ADDRESS = '0x000000000000000000000000000000000000dEaD'
 
-export const VALID_TASK_WITH_PROVIDER_PROTOCOL = {
-  cid: 'QmUuEoBdjC8D1PfWZCc7JCSK8nj7TV6HbXWDHYHzZHCVGS',
-  providerAddress: '/dns4/production-ipfs-peer.pinata.cloud/tcp/3000/ws/p2p/Qma8ddFEQWEU8ijWvdxXm3nxU7oHsRtCykAaVz8WUYhiKn',
-  protocol: 'bitswap'
-}
-Object.freeze(VALID_TASK_WITH_PROVIDER_PROTOCOL)
-
 export const VALID_TASK = {
   cid: 'QmUuEoBdjC8D1PfWZCc7JCSK8nj7TV6HbXWDHYHzZHCVGS',
   minerId: 'f1test'

--- a/test/helpers/test-data.js
+++ b/test/helpers/test-data.js
@@ -1,17 +1,24 @@
 export const VALID_PARTICIPANT_ADDRESS = '0x000000000000000000000000000000000000dEaD'
 
-export const VALID_TASK = {
+export const VALID_TASK_WITH_PROVIDER_PROTOCOL = {
   cid: 'QmUuEoBdjC8D1PfWZCc7JCSK8nj7TV6HbXWDHYHzZHCVGS',
   providerAddress: '/dns4/production-ipfs-peer.pinata.cloud/tcp/3000/ws/p2p/Qma8ddFEQWEU8ijWvdxXm3nxU7oHsRtCykAaVz8WUYhiKn',
   protocol: 'bitswap'
+}
+Object.freeze(VALID_TASK_WITH_PROVIDER_PROTOCOL)
+
+export const VALID_TASK = {
+  cid: 'QmUuEoBdjC8D1PfWZCc7JCSK8nj7TV6HbXWDHYHzZHCVGS',
+  minerId: 'f1test'
 }
 Object.freeze(VALID_TASK)
 
 /** @type {import('../lib/typings').Measurement} */
 export const VALID_MEASUREMENT = {
   cid: VALID_TASK.cid,
-  provider_address: VALID_TASK.providerAddress,
-  protocol: VALID_TASK.protocol,
+  minerId: VALID_TASK.minerId,
+  provider_address: '/dns4/production-ipfs-peer.pinata.cloud/tcp/3000/ws/p2p/Qma8ddFEQWEU8ijWvdxXm3nxU7oHsRtCykAaVz8WUYhiKn',
+  protocol: 'bitswap',
   participantAddress: VALID_PARTICIPANT_ADDRESS,
   inet_group: 'some-group-id',
   status_code: 200,

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -133,6 +133,23 @@ describe('retrieval statistics', () => {
     assertPointFieldValue(point, 'duration_mean', undefined)
     assertPointFieldValue(point, 'duration_p90', undefined)
   })
+
+  it('includes minerId in task definition', () => {
+    const measurements = [
+      {
+        ...VALID_MEASUREMENT,
+        minerId: 'f1one'
+      },
+      {
+        ...VALID_MEASUREMENT,
+        minerId: 'f1two'
+      }
+    ]
+    const point = new Point('stats')
+    buildRetrievalStats(measurements, point)
+    debug('stats', point.fields)
+    assertPointFieldValue(point, 'unique_tasks', '2i')
+  })
 })
 
 describe('getValueAtPercentile', () => {
@@ -172,7 +189,6 @@ describe('recordCommitteeSizes', () => {
         ...VALID_MEASUREMENT,
         cid: 'bafyanother'
       }
-
     ]
 
     const point = new Point('committees')


### PR DESCRIPTION
When checking whether a measurement is for a valid round task, compare both `cid` and `minerId` fields

When picking a checker node in an IPv4 subnet to receive the reward, include `minerId` in the grouping key: When two nodes in the same subnet retrieve the same CID but from different miners, they should be both rewarded.

In practice, this second change will manifest very infrequently, because it's unprobable to have a single round with two tasks for the same CID.  As a result, I did not need to make any changes to the integration test running against real measurements.

Links:
- https://github.com/filecoin-station/spark-evaluate/pull/176
- https://github.com/filecoin-station/roadmap/issues/65

**Out of scope:**

Covered by future tasks in https://github.com/filecoin-station/roadmap/issues/65:

- Modify fraud detection (committee building) in spark-evaluate to cross-check ProviderID.
- Update spark-evaluate to calculate per-miner stats for each round and visualise these stats in our internal dashboards
- Measure and visualise requests per storage provider - https://github.com/filecoin-station/roadmap/issues/64
