### PR TITLE
feat: record RSR per miner id

### DIFF
--- a/lib/public-stats.js
+++ b/lib/public-stats.js
@@ -11,18 +11,24 @@ const debug = createDebug('spark:public-stats')
  * @param {import('./preprocess').Measurement[]} args.honestMeasurements
  */
 export const updatePublicStats = async ({ createPgClient, honestMeasurements }) => {
-  const retrievalStats = { total: 0, successful: 0 }
+  /** @type {Map<string, {{total: number, successful: number}}>} */
+  const minerRetrievalStats = new Map()
   const participants = new Set()
   for (const m of honestMeasurements) {
+    const minerId = m.minerId
+    const retrievalStats = minerRetrievalStats.get(minerId) ?? { total: 0, successful: 0 }
     retrievalStats.total++
     if (m.retrievalResult === 'OK') retrievalStats.successful++
+    minerRetrievalStats.set(minerId, retrievalStats)
 
     participants.add(m.participantAddress)
   }
 
   const pgClient = await createPgClient()
   try {
-    await updateRetrievalStats(pgClient, retrievalStats)
+    for (const [minerId, retrievalStats] of minerRetrievalStats.entries()) {
+      await updateRetrievalStats(pgClient, minerId, retrievalStats)
+    }
     await updateDailyParticipants(pgClient, participants)
     await updateIndexerQueryStats(pgClient, honestMeasurements)
   } finally {
@@ -32,21 +38,23 @@ export const updatePublicStats = async ({ createPgClient, honestMeasurements }) 
 
 /**
  * @param {import('pg').Client} pgClient
+ * @param {string} minerId
  * @param {object} stats
  * @param {number} stats.total
  * @param {number} stats.successful
  */
-const updateRetrievalStats = async (pgClient, { total, successful }) => {
-  debug('Updating public retrieval stats: total += %s successful += %s', total, successful)
+const updateRetrievalStats = async (pgClient, minerId, { total, successful }) => {
+  debug('Updating public retrieval stats for miner %s: total += %s successful += %s', minerId, total, successful)
   await pgClient.query(`
     INSERT INTO retrieval_stats
-      (day, total, successful)
+      (day, miner_id, total, successful)
     VALUES
-      (now(), $1, $2)
-    ON CONFLICT(day) DO UPDATE SET
-      total = retrieval_stats.total + $1,
-      successful = retrieval_stats.successful + $2
+      (now(), $1, $2, $3)
+    ON CONFLICT(day, miner_id) DO UPDATE SET
+      total = retrieval_stats.total + $2,
+      successful = retrieval_stats.successful + $3
   `, [
+    minerId,
     total,
     successful
   ])

--- a/migrations/005.do.miner-retrieval-stats.sql
+++ b/migrations/005.do.miner-retrieval-stats.sql
@@ -1,0 +1,20 @@
+ALTER TABLE retrieval_stats
+ADD COLUMN miner_id TEXT;
+
+-- We don't have miner_id for historical measurements.
+-- Let's set the id to a special constant that's not a valid actor address.
+UPDATE retrieval_stats SET miner_id = 'LEGACY';
+
+-- Going forwards, all new stats must be linked to a particular miner
+ALTER TABLE retrieval_stats
+ALTER COLUMN miner_id SET NOT NULL;
+
+-- Change the primary key to a composite pair (day, miner_id)
+ALTER TABLE retrieval_stats
+DROP CONSTRAINT retrieval_stats_pkey;
+
+ALTER TABLE retrieval_stats
+ADD PRIMARY KEY (day, miner_id);
+
+-- Add back index on retrieval_stats
+CREATE INDEX retrieval_stats_day ON retrieval_stats (day);

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -86,6 +86,7 @@ describe('evaluate', () => {
     const { rows: publicStats } = await pgClient.query('SELECT * FROM retrieval_stats')
     assert.deepStrictEqual(publicStats, [{
       day: today(),
+      miner_id: VALID_TASK.minerId,
       total: 1,
       successful: 1
     }])


### PR DESCRIPTION
I verified that read queries executed by [spark-stats](https://github.com/filecoin-station/spark-stats/) keep working with the new DB schema.

Links:
- https://github.com/filecoin-station/roadmap/issues/65
