### PR TITLE
fix: print telemetry via debug log

### DIFF
--- a/lib/telemetry.js
+++ b/lib/telemetry.js
@@ -1,4 +1,7 @@
 import { InfluxDB, Point } from '@influxdata/influxdb-client'
+import createDebug from 'debug'
+
+const debug = createDebug('spark:evaluate:telemetry')
 
 const influx = new InfluxDB({
   url: 'https://eu-central-1-1.aws.cloud2.influxdata.com',
@@ -19,7 +22,7 @@ export const recordTelemetry = (name, fn) => {
   const point = new Point(name)
   fn(point)
   writeClient.writePoint(point)
-  console.log('TELEMETRY %s %o', name, point)
+  debug('%s %o', name, point)
 }
 
 export const close = () => writeClient.close()


### PR DESCRIPTION
Telemetry points have a lot of fields. Printing them via console.log puts too much pressure on our log ingestion system.

This commit changes `console.log()` to `debug()` to keep these logs available during development.