### PR TITLE
feat: dry run for the last round

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,30 @@ $ WALLET_SEED=$(cat secrets/mnemonic) npm start
 
 You can perform a dry-run evaluation of a given Meridan round using the script `bin/dry-run.js`.
 
-At the moment, the script requires CID(s) of measurements to load. (In the future, we may discover
-those CIDs from on-chain events.)
+1. Get your GLIF API access token at https://api.node.glif.io/
 
-Example: evaluate round `273` of Meridian version `0x3113b83ccec38a18df936f31297de490485d7b2e` with measurements from CID `bafybeie5rekb2jox77ow64wjjd2bjdsp6d3yeivhzzd234hnbpscfjarv4z`.
+2. Save the token to the `.env` file in project's root directory:
+
+   ```ini
+   GLIF_TOKEN="...your-token..."
+   ```
+
+3. Run the dry-run script. By default, the script evaluates the last round of the current smart contract version.
+
+   ```shell
+   node bin/dry-run.js
+   ```
+
+You can optionally specify the smart contract address, round index and list of CIDs of measurements
+to load.  For example, run the following command to evaluate round `273` of the Meridian version
+`0x3113b83ccec38a18df936f31297de490485d7b2e` with measurements from CID
+`bafybeie5rekb2jox77ow64wjjd2bjdsp6d3yeivhzzd234hnbpscfjarv4z`:
 
 ```shell
-❯ node bin/dry-run.js 0x3113b83ccec38a18df936f31297de490485d7b2e 273 bafybeie5rekb2jox77ow64wjjd2bjdsp6d3yeivhzzd234hnbpscfjarv4
+node bin/dry-run.js \
+  0x3113b83ccec38a18df936f31297de490485d7b2e \
+  273 \
+  bafybeie5rekb2jox77ow64wjjd2bjdsp6d3yeivhzzd234hnbpscfjarv4
 ```
 
 ## Deployment

--- a/bin/dry-run.js
+++ b/bin/dry-run.js
@@ -1,3 +1,6 @@
+// IMPORTANT! We must run dotenv config as the very first thing before importing anything else
+import 'dotenv/config'
+
 import { IE_CONTRACT_ADDRESS, RPC_URL, rpcHeaders } from '../lib/config.js'
 import { evaluate } from '../lib/evaluate.js'
 import { preprocess, fetchMeasurements } from '../lib/preprocess.js'
@@ -13,7 +16,7 @@ const cacheDir = fileURLToPath(new URL('../.cache', import.meta.url))
 await mkdir(cacheDir, { recursive: true })
 
 const [nodePath, selfPath, ...args] = process.argv
-if (!args[0].startsWith('0x')) {
+if (args.length === 0 || !args[0].startsWith('0x')) {
   args.unshift(IE_CONTRACT_ADDRESS)
 }
 const [contractAddress, roundIndexStr, ...measurementCids] = args
@@ -29,12 +32,14 @@ if (!contractAddress) {
   process.exit(1)
 }
 
-if (!roundIndexStr) {
-  console.error('Missing required argument: roundIndex')
-  console.log(USAGE)
-  process.exit(1)
+let roundIndex
+if (roundIndexStr) {
+  roundIndex = Number(roundIndexStr)
+} else {
+  console.log('Round index not specified, fetching the last round index from the smart contract')
+  const currentRoundIndex = await fetchLastRoundIndex()
+  roundIndex = Number(currentRoundIndex - 1n)
 }
-const roundIndex = Number(roundIndexStr)
 
 if (!measurementCids.length) {
   measurementCids.push(...(await fetchMeasurementsAddedEvents(BigInt(roundIndex))))
@@ -126,7 +131,7 @@ async function fetchMeasurementsAddedEvents (roundIndex) {
   return list
 }
 
-async function fetchMeasurementsAddedFromChain (roundIndex) {
+async function createIeContract () {
   const fetchRequest = new ethers.FetchRequest(RPC_URL)
   fetchRequest.setHeader('Authorization', rpcHeaders.Authorization || '')
   const provider = new ethers.JsonRpcProvider(
@@ -145,6 +150,12 @@ async function fetchMeasurementsAddedFromChain (roundIndex) {
     ),
     provider
   )
+
+  return { provider, ieContract }
+}
+
+async function fetchMeasurementsAddedFromChain (roundIndex) {
+  const { provider, ieContract } = await createIeContract()
 
   console.log('Fetching MeasurementsAdded events from the ledger')
 
@@ -183,6 +194,11 @@ async function fetchMeasurementsAddedFromChain (roundIndex) {
   }
 
   return events.filter(e => e.roundIndex === roundIndex).map(e => e.cid)
+}
+
+async function fetchLastRoundIndex () {
+  const { ieContract } = await createIeContract()
+  return await ieContract.currentRoundIndex()
 }
 
 function createNoopPgClient () {

--- a/bin/dry-run.js
+++ b/bin/dry-run.js
@@ -132,6 +132,12 @@ async function fetchMeasurementsAddedEvents (roundIndex) {
 }
 
 async function createIeContract () {
+  if (RPC_URL.includes('glif')) {
+    if (!rpcHeaders.Authorization) {
+      throw new Error('Missing required env var GLIF_TOKEN. See https://api.node.glif.io/')
+    }
+  }
+
   const fetchRequest = new ethers.FetchRequest(RPC_URL)
   fetchRequest.setHeader('Authorization', rpcHeaders.Authorization || '')
   const provider = new ethers.JsonRpcProvider(

--- a/bin/dry-run.js
+++ b/bin/dry-run.js
@@ -1,4 +1,4 @@
-// IMPORTANT! We must run dotenv config as the very first thing before importing anything else
+// dotenv must be imported before importing anything else
 import 'dotenv/config'
 
 import { IE_CONTRACT_ADDRESS, RPC_URL, rpcHeaders } from '../lib/config.js'
@@ -132,10 +132,8 @@ async function fetchMeasurementsAddedEvents (roundIndex) {
 }
 
 async function createIeContract () {
-  if (RPC_URL.includes('glif')) {
-    if (!rpcHeaders.Authorization) {
-      throw new Error('Missing required env var GLIF_TOKEN. See https://api.node.glif.io/')
-    }
+  if (RPC_URL.includes('glif') && !process.env.GLIF_TOKEN) {
+    throw new Error('Missing required env var GLIF_TOKEN. See https://api.node.glif.io/')
   }
 
   const fetchRequest = new ethers.FetchRequest(RPC_URL)

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,7 +14,7 @@ const RPC_URL = rpcUrls[Math.floor(Math.random() * rpcUrls.length)]
 console.log(`Selected JSON-RPC endpoint ${RPC_URL}`)
 
 const rpcHeaders = {}
-if (RPC_URL.includes('glif') && GLIF_TOKEN) {
+if (RPC_URL.includes('glif')) {
   rpcHeaders.Authorization = `Bearer ${GLIF_TOKEN}`
 }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,10 +14,7 @@ const RPC_URL = rpcUrls[Math.floor(Math.random() * rpcUrls.length)]
 console.log(`Selected JSON-RPC endpoint ${RPC_URL}`)
 
 const rpcHeaders = {}
-if (RPC_URL.includes('glif')) {
-  if (!GLIF_TOKEN) {
-    throw new Error('Missing required env var GLIF_TOKEN. See https://api.node.glif.io/')
-  }
+if (RPC_URL.includes('glif') && GLIF_TOKEN) {
   rpcHeaders.Authorization = `Bearer ${GLIF_TOKEN}`
 }
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -15,6 +15,9 @@ console.log(`Selected JSON-RPC endpoint ${RPC_URL}`)
 
 const rpcHeaders = {}
 if (RPC_URL.includes('glif')) {
+  if (!GLIF_TOKEN) {
+    throw new Error('Missing required env var GLIF_TOKEN. See https://api.node.glif.io/')
+  }
   rpcHeaders.Authorization = `Bearer ${GLIF_TOKEN}`
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "spark-evaluate",
+  "name": "evaluate",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -21,6 +21,7 @@
         "postgrator": "^7.2.0"
       },
       "devDependencies": {
+        "dotenv": "^16.4.5",
         "mocha": "^10.4.0",
         "standard": "^17.1.0"
       }
@@ -1122,6 +1123,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test": "standard && mocha"
   },
   "devDependencies": {
+    "dotenv": "^16.4.5",
     "mocha": "^10.4.0",
     "standard": "^17.1.0"
   },


### PR DESCRIPTION
Improve `bin/dry-run.js` to fetch the index of the last round from on-chain state.

Add dotenv integration to allow developers to keep the Glif API token in the `.env` file.
