### PR TITLE
ci: dry-run evaluation of the last Spark round

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: npm test
+      - name: Evaluate the last Spark round in a dry-run mode
+        run: node bin/dry-run.js
+        env:
+          GLIF_TOKEN: ${{ secrets.GLIF_TOKEN }}
+
 
   docker-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: npm test
-      - name: Evaluate the last Spark round in a dry-run mode
+      - name: Evaluate the last Spark round in dry-run mode
         run: node bin/dry-run.js
         env:
           GLIF_TOKEN: ${{ secrets.GLIF_TOKEN }}

--- a/bin/dry-run.js
+++ b/bin/dry-run.js
@@ -107,7 +107,8 @@ const ieContractWithSigner = {
   }
 }
 
-await evaluate({
+const started = Date.now()
+const { ignoredErrors } = await evaluate({
   roundIndex,
   round,
   fetchRoundDetails,
@@ -117,7 +118,17 @@ await evaluate({
   createPgClient
 })
 
+console.log('Duration: %sms', Date.now() - started)
 console.log(process.memoryUsage())
+
+if (ignoredErrors.length) {
+  console.log('**ERRORS**')
+  for (const err of ignoredErrors) {
+    console.log()
+    console.log(err)
+  }
+  process.exit(1)
+}
 
 async function fetchMeasurementsAddedEvents (roundIndex) {
   const pathOfCachedResponse = path.join(cacheDir, 'round-' + roundIndex + '.json')

--- a/bin/dry-run.js
+++ b/bin/dry-run.js
@@ -38,7 +38,7 @@ if (roundIndexStr) {
 } else {
   console.log('Round index not specified, fetching the last round index from the smart contract')
   const currentRoundIndex = await fetchLastRoundIndex()
-  roundIndex = Number(currentRoundIndex - 1n)
+  roundIndex = Number(currentRoundIndex - 2n)
 }
 
 if (!measurementCids.length) {

--- a/bin/dry-run.js
+++ b/bin/dry-run.js
@@ -1,7 +1,7 @@
 // dotenv must be imported before importing anything else
 import 'dotenv/config'
 
-import { IE_CONTRACT_ADDRESS, RPC_URL, rpcHeaders } from '../lib/config.js'
+import { DATABASE_URL, IE_CONTRACT_ADDRESS, RPC_URL, rpcHeaders } from '../lib/config.js'
 import { evaluate } from '../lib/evaluate.js'
 import { preprocess, fetchMeasurements } from '../lib/preprocess.js'
 import { fetchRoundDetails } from '../lib/spark-api.js'
@@ -10,6 +10,7 @@ import { readFile, writeFile, mkdir } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { ethers } from 'ethers'
+import pg from 'pg'
 import { RoundData } from '../lib/round.js'
 
 const cacheDir = fileURLToPath(new URL('../.cache', import.meta.url))
@@ -54,6 +55,12 @@ const recordTelemetry = (measurementName, fn) => {
   const point = new Point(measurementName)
   fn(point)
   console.log('TELEMETRY %s %o', measurementName, point.fields)
+}
+
+const createPgClient = async () => {
+  const pgClient = new pg.Client({ connectionString: DATABASE_URL })
+  await pgClient.connect()
+  return pgClient
 }
 
 const fetchMeasurementsWithCache = async (cid) => {
@@ -107,13 +114,7 @@ await evaluate({
   ieContractWithSigner,
   logger: console,
   recordTelemetry,
-
-  // We don't want dry runs to update data in `sparks_stats`, therefore we are passing a stub
-  // connection factory that creates no-op clients. This also keeps the setup simpler. The person
-  // executing a dry run does not need access to any Postgres instance.
-  // Evaluate uses the PG client only for updating the statistics, it's not reading any data.
-  // Thus it's safe to inject a no-op client.
-  createPgClient: createNoopPgClient
+  createPgClient
 })
 
 console.log(process.memoryUsage())
@@ -203,15 +204,4 @@ async function fetchMeasurementsAddedFromChain (roundIndex) {
 async function fetchLastRoundIndex () {
   const { ieContract } = await createIeContract()
   return await ieContract.currentRoundIndex()
-}
-
-function createNoopPgClient () {
-  return {
-    async query () {
-      return { rows: [] }
-    },
-    async end () {
-      // no-op
-    }
-  }
 }

--- a/bin/dry-run.js
+++ b/bin/dry-run.js
@@ -176,7 +176,7 @@ async function fetchMeasurementsAddedFromChain (roundIndex) {
 
   /** @type {Array<{ cid: string, roundIndex: bigint, sender: string }>} */
   const events = rawEvents.map(({ args: [cid, roundIndex, sender] }) => ({ cid, roundIndex, sender }))
-  console.log('events', events)
+  // console.log('events', events)
 
   const prev = roundIndex - 1n
   const prevFound = events.some(e => e.roundIndex === prev)

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -192,6 +192,8 @@ export const evaluate = async ({
     }
   })
 
+  const ignoredErrors = []
+
   try {
     recordTelemetry('retrieval_stats_honest', (point) => {
       point.intField('round_index', roundIndex)
@@ -199,6 +201,7 @@ export const evaluate = async ({
     })
   } catch (err) {
     console.error('Cannot record retrieval stats (honest).', err)
+    ignoredErrors.push(err)
     Sentry.captureException(err)
   }
 
@@ -209,6 +212,7 @@ export const evaluate = async ({
     })
   } catch (err) {
     console.error('Cannot record retrieval stats (all).', err)
+    ignoredErrors.push(err)
     Sentry.captureException(err)
   }
 
@@ -219,6 +223,7 @@ export const evaluate = async ({
     })
   } catch (err) {
     console.error('Cannot record committees.', err)
+    ignoredErrors.push(err)
     Sentry.captureException(err)
   }
 
@@ -226,8 +231,11 @@ export const evaluate = async ({
     await updatePublicStats({ createPgClient, honestMeasurements })
   } catch (err) {
     console.error('Cannot update public stats.', err)
+    ignoredErrors.push(err)
     Sentry.captureException(err)
   }
+
+  return { ignoredErrors }
 }
 
 /**


### PR DESCRIPTION
Our test suite uses relatively small datasets to test the evaluation pipeline. In this PR, I am adding another build/test step to dry-run the evaluation of a real round, to catch possible errors that are triggered only by large datasets.

Additional changes to make this new CI step useful:
- fix: calculation of the last round index
- feat: write stats to a real DB in dry-run
- fix: remove noisy event log in dry-run 
- report duration of the `evaluate()` call
- feat: crash dry-run on errors ignored in production

This PR is a follow-up for
- https://github.com/filecoin-station/spark-evaluate/pull/194

/cc @PatrickNercessian
