### PR TITLE
platform-stats: fix ignore empty station id

### DIFF
--- a/lib/platform-stats.js
+++ b/lib/platform-stats.js
@@ -18,7 +18,13 @@ export const updateDailyStationStats = async (pgClient, honestMeasurements) => {
   // TODO: when we add more fields, we will update the ON CONFLICT clause
   // to update those fields, and we won't just use a Set for the stationIds
   // which currently removes all granular measurement details
-  const stationIds = [...new Set(honestMeasurements.map(m => m.stationId))]
+  const stationIds = [
+    ...new Set(
+      honestMeasurements
+        .filter(m => m.stationId !== null)
+        .map(m => m.stationId)
+    )
+  ]
   debug('Updating daily station stats, unique_count=%s', stationIds.length)
 
   await pgClient.query(`

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -53,7 +53,7 @@ export const preprocess = async ({
   const measurements = await pRetry(
     () => fetchMeasurements(cid),
     {
-      retries: 20,
+      retries: 10,
       onFailedAttempt: err => {
         console.error(err)
         console.error(`Retrying ${cid} ${err.retriesLeft} more times`)

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -53,7 +53,7 @@ export const preprocess = async ({
   const measurements = await pRetry(
     () => fetchMeasurements(cid),
     {
-      retries: 10,
+      retries: 20,
       onFailedAttempt: err => {
         console.error(err)
         console.error(`Retrying ${cid} ${err.retriesLeft} more times`)

--- a/test/platform-stats.test.js
+++ b/test/platform-stats.test.js
@@ -72,6 +72,19 @@ describe('platform-stats', () => {
       assert.strictEqual(rows.length, 1)
       assert.deepStrictEqual(rows, [{ station_id: VALID_STATION_ID, day: today }])
     })
+
+    it('ignores measurements without .stationId', async () => {
+      const honestMeasurements = [
+        { ...VALID_MEASUREMENT, stationId: null },
+        { ...VALID_MEASUREMENT, stationId: VALID_STATION_ID }
+      ]
+
+      await updateDailyStationStats(pgClient, honestMeasurements)
+
+      const { rows } = await pgClient.query('SELECT station_id, day::TEXT FROM daily_stations')
+      assert.strictEqual(rows.length, 1)
+      assert.deepStrictEqual(rows, [{ station_id: VALID_STATION_ID, day: today }])
+    })
   })
 
   const getCurrentDate = async () => {


### PR DESCRIPTION
Fixes dry run error

```
error: null value in column "station_id" of relation "daily_stations" violates not-null constraint
```