### PR TITLE
refactor: move participant stats to platform stats

### DIFF
--- a/lib/platform-stats.js
+++ b/lib/platform-stats.js
@@ -1,3 +1,4 @@
+import assert from 'node:assert'
 import createDebug from 'debug'
 
 const debug = createDebug('spark:platform-stats')
@@ -7,6 +8,8 @@ const debug = createDebug('spark:platform-stats')
  * @param {import('./preprocess').Measurement[]} honestMeasurements
  */
 export const updatePlatformStats = async (pgClient, honestMeasurements) => {
+  const participants = new Set(honestMeasurements.map(m => m.participantAddress))
+  await updateDailyParticipants(pgClient, participants)
   await updateDailyStationStats(pgClient, honestMeasurements)
 }
 
@@ -32,4 +35,83 @@ export const updateDailyStationStats = async (pgClient, honestMeasurements) => {
     SELECT unnest($1::text[]), now()
     ON CONFLICT (station_id, day) DO NOTHING
   `, [stationIds])
+}
+
+/**
+ * @param {import('pg').Client} pgClient
+ * @param {Set<string>} participants
+ */
+export const updateDailyParticipants = async (pgClient, participants) => {
+  debug('Updating daily participants, count=%s', participants.size)
+  const ids = await mapParticipantsToIds(pgClient, participants)
+  await pgClient.query(`
+    INSERT INTO daily_participants (day, participant_id)
+    SELECT now() as day, UNNEST($1::INT[]) AS participant_id
+    ON CONFLICT DO NOTHING
+  `, [
+    ids
+  ])
+}
+
+/**
+ * @param {import('pg').Client} pgClient
+ * @param {Set<string>} participantsSet
+ * @returns {Promise<string[]>} A list of participant ids. The order of ids is not defined.
+ */
+export const mapParticipantsToIds = async (pgClient, participantsSet) => {
+  debug('Mapping participants to id, count=%s', participantsSet.size)
+
+  /** @type {string[]} */
+  const ids = []
+
+  // TODO: We can further optimise performance of this function by using
+  // an in-memory LRU cache. Our network has currently ~2k participants,
+  // we need ~50 bytes for each (address, id) pair, that's only ~100KB of data.
+
+  // TODO: passing the entire list of participants as a single query parameter
+  // will probably not scale beyond several thousands of addresses. We will
+  // need to rework the queries to split large arrays into smaller batches.
+
+  // In most rounds, we have already seen most of the participant addresses
+  // If we use "INSERT...ON CONFLICT", then PG increments id counter even for
+  // existing addresses where we end up skipping the insert. This could quickly
+  // exhaust the space of all 32bit integers.
+  // Solution: query the table for know records before running the insert.
+  //
+  // Caveat: In my testing, this query was not able to leverage the (unique)
+  // index on participants.participant_address and performed a full table scan
+  // after the array grew past ~10 items. If this becomes a problem, we can
+  // introduce the LRU cache mentioned above.
+  const { rows: found } = await pgClient.query(
+    'SELECT * FROM participants WHERE participant_address = ANY($1::TEXT[])',
+    [Array.from(participantsSet.values())]
+  )
+  debug('Known participants count=%s', found.length)
+
+  // eslint-disable-next-line camelcase
+  for (const { id, participant_address } of found) {
+    ids.push(id)
+    participantsSet.delete(participant_address)
+  }
+
+  debug('New participant addresses count=%s', participantsSet.size)
+
+  // Register the new addresses. Use "INSERT...ON CONFLICT" to handle the race condition
+  // where another client may have registered these addresses between our previous
+  // SELECT query and the next INSERT query.
+  const newAddresses = Array.from(participantsSet.values())
+  debug('Registering new participant addresses, count=%s', newAddresses.length)
+  const { rows: created } = await pgClient.query(`
+    INSERT INTO participants (participant_address)
+    SELECT UNNEST($1::TEXT[]) AS participant_address
+    ON CONFLICT(participant_address) DO UPDATE
+      -- this no-op update is needed to populate "RETURNING id"
+      SET participant_address = EXCLUDED.participant_address
+    RETURNING id
+  `, [
+    newAddresses
+  ])
+
+  assert.strictEqual(created.length, newAddresses.length)
+  return ids.concat(created.map(r => r.id))
 }

--- a/lib/public-stats.js
+++ b/lib/public-stats.js
@@ -1,4 +1,3 @@
-import assert from 'node:assert'
 import createDebug from 'debug'
 
 import { updatePlatformStats } from './platform-stats.js'
@@ -30,7 +29,6 @@ export const updatePublicStats = async ({ createPgClient, honestMeasurements }) 
     for (const [minerId, retrievalStats] of minerRetrievalStats.entries()) {
       await updateRetrievalStats(pgClient, minerId, retrievalStats)
     }
-    await updateDailyParticipants(pgClient, participants)
     await updateIndexerQueryStats(pgClient, honestMeasurements)
     await updatePlatformStats(pgClient, honestMeasurements)
   } finally {
@@ -62,22 +60,6 @@ const updateRetrievalStats = async (pgClient, minerId, { total, successful }) =>
   ])
 }
 
-/**
- * @param {import('pg').Client} pgClient
- * @param {Set<string>} participants
- */
-export const updateDailyParticipants = async (pgClient, participants) => {
-  debug('Updating daily participants, count=%s', participants.size)
-  const ids = await mapParticipantsToIds(pgClient, participants)
-  await pgClient.query(`
-    INSERT INTO daily_participants (day, participant_id)
-    SELECT now() as day, UNNEST($1::INT[]) AS participant_id
-    ON CONFLICT DO NOTHING
-  `, [
-    ids
-  ])
-}
-
 const updateIndexerQueryStats = async (pgClient, honestMeasurements) => {
   /** @type {Set<string>} */
   const dealsWithHttpAdvertisement = new Set()
@@ -105,67 +87,4 @@ const updateIndexerQueryStats = async (pgClient, honestMeasurements) => {
     tested,
     advertisingHttp
   ])
-}
-
-/**
- * @param {import('pg').Client} pgClient
- * @param {Set<string>} participantsSet
- * @returns {Promise<string[]>} A list of participant ids. The order of ids is not defined.
- */
-export const mapParticipantsToIds = async (pgClient, participantsSet) => {
-  debug('Mapping participants to id, count=%s', participantsSet.size)
-
-  /** @type {string[]} */
-  const ids = []
-
-  // TODO: We can further optimise performance of this function by using
-  // an in-memory LRU cache. Our network has currently ~2k participants,
-  // we need ~50 bytes for each (address, id) pair, that's only ~100KB of data.
-
-  // TODO: passing the entire list of participants as a single query parameter
-  // will probably not scale beyond several thousands of addresses. We will
-  // need to rework the queries to split large arrays into smaller batches.
-
-  // In most rounds, we have already seen most of the participant addresses
-  // If we use "INSERT...ON CONFLICT", then PG increments id counter even for
-  // existing addresses where we end up skipping the insert. This could quickly
-  // exhaust the space of all 32bit integers.
-  // Solution: query the table for know records before running the insert.
-  //
-  // Caveat: In my testing, this query was not able to leverage the (unique)
-  // index on participants.participant_address and performed a full table scan
-  // after the array grew past ~10 items. If this becomes a problem, we can
-  // introduce the LRU cache mentioned above.
-  const { rows: found } = await pgClient.query(
-    'SELECT * FROM participants WHERE participant_address = ANY($1::TEXT[])',
-    [Array.from(participantsSet.values())]
-  )
-  debug('Known participants count=%s', found.length)
-
-  // eslint-disable-next-line camelcase
-  for (const { id, participant_address } of found) {
-    ids.push(id)
-    participantsSet.delete(participant_address)
-  }
-
-  debug('New participant addresses count=%s', participantsSet.size)
-
-  // Register the new addresses. Use "INSERT...ON CONFLICT" to handle the race condition
-  // where another client may have registered these addresses between our previous
-  // SELECT query and the next INSERT query.
-  const newAddresses = Array.from(participantsSet.values())
-  debug('Registering new participant addresses, count=%s', newAddresses.length)
-  const { rows: created } = await pgClient.query(`
-    INSERT INTO participants (participant_address)
-    SELECT UNNEST($1::TEXT[]) AS participant_address
-    ON CONFLICT(participant_address) DO UPDATE
-      -- this no-op update is needed to populate "RETURNING id"
-      SET participant_address = EXCLUDED.participant_address
-    RETURNING id
-  `, [
-    newAddresses
-  ])
-
-  assert.strictEqual(created.length, newAddresses.length)
-  return ids.concat(created.map(r => r.id))
 }

--- a/lib/public-stats.js
+++ b/lib/public-stats.js
@@ -13,15 +13,12 @@ const debug = createDebug('spark:public-stats')
 export const updatePublicStats = async ({ createPgClient, honestMeasurements }) => {
   /** @type {Map<string, {{total: number, successful: number}}>} */
   const minerRetrievalStats = new Map()
-  const participants = new Set()
   for (const m of honestMeasurements) {
     const minerId = m.minerId
     const retrievalStats = minerRetrievalStats.get(minerId) ?? { total: 0, successful: 0 }
     retrievalStats.total++
     if (m.retrievalResult === 'OK') retrievalStats.successful++
     minerRetrievalStats.set(minerId, retrievalStats)
-
-    participants.add(m.participantAddress)
   }
 
   const pgClient = await createPgClient()

--- a/test/platform-stats.test.js
+++ b/test/platform-stats.test.js
@@ -5,7 +5,12 @@ import { beforeEach, describe, it } from 'mocha'
 import { DATABASE_URL } from '../lib/config.js'
 import { migrateWithPgClient } from '../lib/migrate.js'
 import { VALID_MEASUREMENT, VALID_STATION_ID } from './helpers/test-data.js'
-import { updateDailyStationStats } from '../lib/platform-stats.js'
+import {
+  mapParticipantsToIds,
+  updateDailyParticipants,
+  updateDailyStationStats,
+  updatePlatformStats
+} from '../lib/platform-stats.js'
 
 const createPgClient = async () => {
   const pgClient = new pg.Client({ connectionString: DATABASE_URL })
@@ -23,6 +28,10 @@ describe('platform-stats', () => {
   let today
   beforeEach(async () => {
     await pgClient.query('DELETE FROM daily_stations')
+
+    await pgClient.query('DELETE FROM daily_participants')
+    // empty `participants` table in such way that the next participants.id will be always 1
+    await pgClient.query('TRUNCATE TABLE participants RESTART IDENTITY CASCADE')
 
     // Run all tests inside a transaction to ensure `now()` always returns the same value
     // See https://dba.stackexchange.com/a/63549/125312
@@ -84,6 +93,71 @@ describe('platform-stats', () => {
       const { rows } = await pgClient.query('SELECT station_id, day::TEXT FROM daily_stations')
       assert.strictEqual(rows.length, 1)
       assert.deepStrictEqual(rows, [{ station_id: VALID_STATION_ID, day: today }])
+    })
+  })
+
+  describe('daily_participants', () => {
+    it('submits daily_participants data for today', async () => {
+      /** @type {import('../lib/preprocess').Measurement[]} */
+      const honestMeasurements = [
+        { ...VALID_MEASUREMENT, participantAddress: '0x10' },
+        { ...VALID_MEASUREMENT, participantAddress: '0x10' },
+        { ...VALID_MEASUREMENT, participantAddress: '0x20' }
+      ]
+      await updatePlatformStats(pgClient, honestMeasurements)
+
+      const { rows } = await pgClient.query(
+        'SELECT day::TEXT, participant_id FROM daily_participants'
+      )
+      assert.deepStrictEqual(rows, [
+        { day: today, participant_id: 1 },
+        { day: today, participant_id: 2 }
+      ])
+    })
+
+    it('creates a new daily_participants row', async () => {
+      await updateDailyParticipants(pgClient, new Set(['0x10', '0x20']))
+
+      const { rows: created } = await pgClient.query(
+        'SELECT day::TEXT, participant_id FROM daily_participants'
+      )
+      assert.deepStrictEqual(created, [
+        { day: today, participant_id: 1 },
+        { day: today, participant_id: 2 }
+      ])
+    })
+
+    it('handles participants already seen today', async () => {
+      await updateDailyParticipants(pgClient, new Set(['0x10', '0x20']))
+      await updateDailyParticipants(pgClient, new Set(['0x10', '0x30', '0x20']))
+
+      const { rows: created } = await pgClient.query(
+        'SELECT day::TEXT, participant_id FROM daily_participants'
+      )
+      assert.deepStrictEqual(created, [
+        { day: today, participant_id: 1 },
+        { day: today, participant_id: 2 },
+        { day: today, participant_id: 3 }
+      ])
+    })
+
+    it('maps new participant addresses to new ids', async () => {
+      const ids = await mapParticipantsToIds(pgClient, new Set(['0x10', '0x20']))
+      ids.sort()
+      assert.deepStrictEqual(ids, [1, 2])
+    })
+
+    it('maps existing participants to their existing ids', async () => {
+      const participants = new Set(['0x10', '0x20'])
+      const first = await mapParticipantsToIds(pgClient, participants)
+      first.sort()
+      assert.deepStrictEqual(first, [1, 2])
+
+      participants.add('0x30')
+      participants.add('0x40')
+      const second = await mapParticipantsToIds(pgClient, participants)
+      second.sort()
+      assert.deepStrictEqual(second, [1, 2, 3, 4])
     })
   })
 

--- a/test/public-stats.test.js
+++ b/test/public-stats.test.js
@@ -4,7 +4,7 @@ import pg from 'pg'
 import { DATABASE_URL } from '../lib/config.js'
 import { migrateWithPgClient } from '../lib/migrate.js'
 import { VALID_MEASUREMENT } from './helpers/test-data.js'
-import { mapParticipantsToIds, updateDailyParticipants, updatePublicStats } from '../lib/public-stats.js'
+import { updatePublicStats } from '../lib/public-stats.js'
 import { beforeEach } from 'mocha'
 
 const createPgClient = async () => {
@@ -24,9 +24,6 @@ describe('public-stats', () => {
   beforeEach(async () => {
     await pgClient.query('DELETE FROM retrieval_stats')
     await pgClient.query('DELETE FROM indexer_query_stats')
-    await pgClient.query('DELETE FROM daily_participants')
-    // empty `participants` table in such way that the next participants.id will be always 1
-    await pgClient.query('TRUNCATE TABLE participants RESTART IDENTITY CASCADE')
 
     // Run all tests inside a transaction to ensure `now()` always returns the same value
     // See https://dba.stackexchange.com/a/63549/125312
@@ -99,71 +96,6 @@ describe('public-stats', () => {
         { day: today, miner_id: 'f1first', total: 2 + 3, successful: 1 + 1 },
         { day: today, miner_id: 'f1second', total: 1 + 2, successful: 1 + 1 }
       ])
-    })
-  })
-
-  describe('daily_participants', () => {
-    it('submits daily_participants data for today', async () => {
-      /** @type {import('../lib/preprocess').Measurement[]} */
-      const honestMeasurements = [
-        { ...VALID_MEASUREMENT, participantAddress: '0x10' },
-        { ...VALID_MEASUREMENT, participantAddress: '0x10' },
-        { ...VALID_MEASUREMENT, participantAddress: '0x20' }
-      ]
-      await updatePublicStats({ createPgClient, honestMeasurements })
-
-      const { rows } = await pgClient.query(
-        'SELECT day::TEXT, participant_id FROM daily_participants'
-      )
-      assert.deepStrictEqual(rows, [
-        { day: today, participant_id: 1 },
-        { day: today, participant_id: 2 }
-      ])
-    })
-
-    it('creates a new daily_participants row', async () => {
-      await updateDailyParticipants(pgClient, new Set(['0x10', '0x20']))
-
-      const { rows: created } = await pgClient.query(
-        'SELECT day::TEXT, participant_id FROM daily_participants'
-      )
-      assert.deepStrictEqual(created, [
-        { day: today, participant_id: 1 },
-        { day: today, participant_id: 2 }
-      ])
-    })
-
-    it('handles participants already seen today', async () => {
-      await updateDailyParticipants(pgClient, new Set(['0x10', '0x20']))
-      await updateDailyParticipants(pgClient, new Set(['0x10', '0x30', '0x20']))
-
-      const { rows: created } = await pgClient.query(
-        'SELECT day::TEXT, participant_id FROM daily_participants'
-      )
-      assert.deepStrictEqual(created, [
-        { day: today, participant_id: 1 },
-        { day: today, participant_id: 2 },
-        { day: today, participant_id: 3 }
-      ])
-    })
-
-    it('maps new participant addresses to new ids', async () => {
-      const ids = await mapParticipantsToIds(pgClient, new Set(['0x10', '0x20']))
-      ids.sort()
-      assert.deepStrictEqual(ids, [1, 2])
-    })
-
-    it('maps existing participants to their existing ids', async () => {
-      const participants = new Set(['0x10', '0x20'])
-      const first = await mapParticipantsToIds(pgClient, participants)
-      first.sort()
-      assert.deepStrictEqual(first, [1, 2])
-
-      participants.add('0x30')
-      participants.add('0x40')
-      const second = await mapParticipantsToIds(pgClient, participants)
-      second.sort()
-      assert.deepStrictEqual(second, [1, 2, 3, 4])
     })
   })
 


### PR DESCRIPTION
Let's make it easier to share the code that's building participant-related stats between all Meridian projects (Spark, Voyager). One baby step at a time.

/cc @PatrickNercessian