### PR TITLE
preprocess: add delay to improve changes of data being available

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ import { RoundData } from './lib/round.js'
 import timers from 'node:timers/promises'
 
 // Tweak this value to improve the chances of the data being available
-const PREPROCESS_DELAY = 60_1000
+const PREPROCESS_DELAY = 60_000
 
 export const startEvaluate = async ({
   ieContract,

--- a/index.js
+++ b/index.js
@@ -62,15 +62,17 @@ export const startEvaluate = async ({
         logger
       })
     } catch (err) {
+      let errToReport = err
+
       // See https://github.com/filecoin-station/spark-evaluate/issues/36
       // Because each error message contains unique CID, Sentry is not able to group these errors
       // Let's wrap the error message in a new Error object as a cause
       if (typeof err === 'string' && err.match(/ENOENT: no such file or directory, open.*\/bafy/)) {
-        err = new Error('web3.storage cannot find block\'s temp file', { cause: err })
+        errToReport = new Error('web3.storage cannot find block\'s temp file', { cause: err })
       }
 
-      console.error(err)
-      Sentry.captureException(err, {
+      console.error(errToReport)
+      Sentry.captureException(errToReport, {
         extra: {
           roundIndex,
           measurementsCid: cid


### PR DESCRIPTION
As suggested in https://filecoinproject.slack.com/archives/C031K3BG527/p1714658724173009?thread_ts=1714636341.173339&cid=C031K3BG527. Data stored in W3S isn't always immediately available, and especially sometimes trying to fetch it too soon will result in bad responses in the caches.