### PR TITLE
perf: speed up `bin/dry-run.js`

### DIFF
--- a/bin/dry-run.js
+++ b/bin/dry-run.js
@@ -88,7 +88,8 @@ for (const cid of measurementCids) {
     cid,
     fetchMeasurements: fetchMeasurementsWithCache,
     recordTelemetry,
-    logger: console
+    logger: console,
+    retries: 0
   })
 }
 

--- a/bin/dry-run.js
+++ b/bin/dry-run.js
@@ -98,7 +98,7 @@ for (const cid of measurementCids) {
       fetchMeasurements: fetchMeasurementsWithCache,
       recordTelemetry,
       logger: console,
-      retries: 0
+      fetchRetries: 0
     })
   } catch (err) {
     console.error(err)

--- a/bin/dry-run.js
+++ b/bin/dry-run.js
@@ -13,8 +13,6 @@ import { ethers } from 'ethers'
 import pg from 'pg'
 import { RoundData } from '../lib/round.js'
 
-const { CONCURRENCY: concurrency = 4 } = process.env
-
 const cacheDir = fileURLToPath(new URL('../.cache', import.meta.url))
 await mkdir(cacheDir, { recursive: true })
 
@@ -83,20 +81,16 @@ console.log('Evaluating round %s of contract %s', roundIndex, contractAddress)
 
 console.log('==PREPROCESS==')
 const round = new RoundData(roundIndex)
-await Promise.all(new Array(concurrency).fill(null).map(async () => {
-  while (true) {
-    const cid = measurementCids.shift()
-    if (!cid) return
-    await preprocess({
-      roundIndex,
-      round,
-      cid,
-      fetchMeasurements: fetchMeasurementsWithCache,
-      recordTelemetry,
-      logger: console
-    })
-  }
-}))
+for (const cid of measurementCids) {
+  await preprocess({
+    roundIndex,
+    round,
+    cid,
+    fetchMeasurements: fetchMeasurementsWithCache,
+    recordTelemetry,
+    logger: console
+  })
+}
 
 console.log('Fetched %s measurements', round.measurements.length)
 

--- a/bin/dry-run.js
+++ b/bin/dry-run.js
@@ -14,8 +14,6 @@ import { ethers } from 'ethers'
 import pg from 'pg'
 import { RoundData } from '../lib/round.js'
 
-const { CONCURRENCY: concurrency = 4 } = process.env
-
 Sentry.init({
   dsn: 'https://d0651617f9690c7e9421ab9c949d67a4@o1408530.ingest.sentry.io/4505906069766144',
   environment: process.env.SENTRY_ENVIRONMENT || 'dry-run',
@@ -91,31 +89,27 @@ console.log('Evaluating round %s of contract %s', roundIndex, contractAddress)
 
 console.log('==PREPROCESS==')
 const round = new RoundData(roundIndex)
-await Promise.all(new Array(concurrency).fill(null).map(async () => {
-  while (true) {
-    const cid = measurementCids.shift()
-    if (!cid) return
-    try {
-      await preprocess({
+for (const cid of measurementCids) {
+  try {
+    await preprocess({
+      roundIndex,
+      round,
+      cid,
+      fetchMeasurements: fetchMeasurementsWithCache,
+      recordTelemetry,
+      logger: console,
+      retries: 0
+    })
+  } catch (err) {
+    console.error(err)
+    Sentry.captureException(err, {
+      extra: {
         roundIndex,
-        round,
-        cid,
-        fetchMeasurements: fetchMeasurementsWithCache,
-        recordTelemetry,
-        logger: console,
-        retries: 0
-      })
-    } catch (err) {
-      console.error(err)
-      Sentry.captureException(err, {
-        extra: {
-          roundIndex,
-          measurementsCid: cid
-        }
-      })
-    }
+        measurementsCid: cid
+      }
+    })
   }
-}))
+}
 
 console.log('Fetched %s measurements', round.measurements.length)
 

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -51,14 +51,15 @@ export const preprocess = async ({
   roundIndex,
   fetchMeasurements,
   recordTelemetry,
-  logger
+  logger,
+  retries = 14
 }) => {
   const start = Date.now()
   /** @type import('./typings.js').RawMeasurement[] */
   const measurements = await pRetry(
     () => fetchMeasurements(cid),
     {
-      retries: 14,
+      retries,
       onFailedAttempt: err => {
         console.error(err)
         console.error(`Retrying ${cid} ${err.retriesLeft} more times`)

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -52,14 +52,14 @@ export const preprocess = async ({
   fetchMeasurements,
   recordTelemetry,
   logger,
-  retries = 14
+  fetchRetries = 14
 }) => {
   const start = Date.now()
   /** @type import('./typings.js').RawMeasurement[] */
   const measurements = await pRetry(
     () => fetchMeasurements(cid),
     {
-      retries,
+      retries: fetchRetries,
       onFailedAttempt: err => {
         console.error(err)
         console.error(`Retrying ${cid} ${err.retriesLeft} more times`)


### PR DESCRIPTION
Noticed in https://github.com/filecoin-station/spark-evaluate/actions/runs/8995936280/job/24711656364?pr=205 that it can take a while. While most of the time there is waiting for w3s data to become available, even without it will take minutes