### PR TITLE
fix: rewards per inet group

### DIFF
--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -1,7 +1,7 @@
 import createDebug from 'debug'
 import assert from 'node:assert'
 import * as Sentry from '@sentry/node'
-import { buildRetrievalStats, recordCommitteeSizes } from './retrieval-stats.js'
+import { buildRetrievalStats, getTaskId, recordCommitteeSizes } from './retrieval-stats.js'
 import { updatePublicStats } from './public-stats.js'
 
 const debug = createDebug('spark:evaluate')
@@ -259,15 +259,15 @@ export const runFraudDetection = async (roundIndex, measurements, sparkRoundDeta
   // 2. Reward only one participant in each inet group
   //
   /** @type {Map<string, import('./preprocess.js').Measurement[]>} */
-  const taskGroups = new Map()
+  const inetGroups = new Map()
   for (const m of measurements) {
     if (m.fraudAssessment) continue
 
-    const key = `${m.inet_group}::${m.cid}::${m.minerId}`
-    let group = taskGroups.get(key)
+    const key = m.inet_group
+    let group = inetGroups.get(key)
     if (!group) {
       group = []
-      taskGroups.set(key, group)
+      inetGroups.set(key, group)
     }
 
     group.push(m)
@@ -278,10 +278,12 @@ export const runFraudDetection = async (roundIndex, measurements, sparkRoundDeta
     return Buffer.from(bytes).toString('hex')
   }
 
-  for (const [key, groupMeasurements] of taskGroups.entries()) {
-    debug('Evaluating measurements in group %s', key)
+  for (const [key, groupMeasurements] of inetGroups.entries()) {
+    debug('Evaluating measurements from inet group %s', key)
 
-    // Pick one measurement to reward and mark all others as not eligible for rewards
+    // Pick one measurement per task to reward and mark all others as not eligible for rewards.
+    // We also want to reward at most `maxTasksPerNode` measurements in each inet group.
+    //
     // The difficult part: how to choose a measurement randomly but also fairly, so
     // that each measurement has the same chance of being picked for the reward?
     // We also want the selection algorithm to be deterministic.
@@ -294,35 +296,32 @@ export const runFraudDetection = async (roundIndex, measurements, sparkRoundDeta
     // 2. Pick the measurement with the lowest hash value
     // This relies on the fact that the hash function has a random distribution.
     // We are also making the assumption that each measurement has a distinct `finished_at` field.
+    //
+    const measurementsWithHash = await Promise.all(
+      groupMeasurements.map(async (m) => ({ m, h: await getHash(m) }))
+    )
+    // Sort measurements using the computed hash
+    measurementsWithHash.sort((a, b) => a.h < b.h ? -1 : a.h > b.h ? 1 : 0)
 
-    const chosen = { m: groupMeasurements[0], h: await getHash(groupMeasurements[0]) }
-    debug('  m[0] pa: %s h: %s', chosen.m.participantAddress, chosen.h)
-    for (let i = 1; i < groupMeasurements.length; i++) {
-      const m = groupMeasurements[i]
-      const h = await getHash(m)
-      debug('  m[%s] pa: %s h: %s', i, m.participantAddress, h)
-      if (h < chosen.h) {
-        debug('  ^^ new winner')
-        chosen.m = m
-        chosen.h = h
+    const tasksSeen = new Set()
+    for (const { m, h } of measurementsWithHash) {
+      const taskId = getTaskId(m)
+
+      if (tasksSeen.has(taskId)) {
+        debug('  pa: %s h: %s task: %s - task was already rewarded', m.participantAddress, h, taskId)
+        m.fraudAssessment = 'DUP_INET_GROUP'
+        continue
       }
-    }
 
-    for (const m of groupMeasurements) {
-      m.fraudAssessment = m === chosen.m ? 'OK' : 'DUP_INET_GROUP'
-    }
-  }
+      if (tasksSeen.size >= sparkRoundDetails.maxTasksPerNode) {
+        debug('  pa: %s h: %s task: %s - already rewarded max tasks', m.participantAddress, h, taskId)
+        m.fraudAssessment = 'TOO_MANY_TASKS'
+        continue
+      }
 
-  //
-  // 3. Reward only first TN measurements
-  //
-  const tasksPerNode = new Map()
-  for (const m of measurements) {
-    if (m.fraudAssessment && m.fraudAssessment !== 'OK') continue
-    const node = `${m.inet_group}::${m.participantAddress}`
-    tasksPerNode.set(node, (tasksPerNode.get(node) ?? 0) + 1)
-    if (tasksPerNode.get(node) > sparkRoundDetails.maxTasksPerNode) {
-      m.fraudAssessment = 'TOO_MANY_TASKS'
+      tasksSeen.add(taskId)
+      m.fraudAssessment = 'OK'
+      debug('  pa: %s h: %s task: %s - REWARD', m.participantAddress, h, taskId)
     }
   }
 

--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -301,7 +301,7 @@ export const runFraudDetection = async (roundIndex, measurements, sparkRoundDeta
       groupMeasurements.map(async (m) => ({ m, h: await getHash(m) }))
     )
     // Sort measurements using the computed hash
-    measurementsWithHash.sort((a, b) => a.h < b.h ? -1 : a.h > b.h ? 1 : 0)
+    measurementsWithHash.sort((a, b) => a.h.localeCompare(b.h, 'en'))
 
     const tasksSeen = new Set()
     for (const { m, h } of measurementsWithHash) {

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -437,6 +437,7 @@ describe('fraud detection', () => {
         { ...VALID_TASK, cid: 'cid2', minerId: 'f1second' }
       ]
     }
+
     const measurements = [
       // the first participant completes tasks #1 and #4
       { ...VALID_MEASUREMENT, ...sparkRoundDetails.retrievalTasks[0], participantAddress: 'pa1' },
@@ -445,6 +446,10 @@ describe('fraud detection', () => {
       { ...VALID_MEASUREMENT, ...sparkRoundDetails.retrievalTasks[1], participantAddress: 'pa2' },
       { ...VALID_MEASUREMENT, ...sparkRoundDetails.retrievalTasks[2], participantAddress: 'pa2' }
     ]
+
+    // Ensure `finished_at` values are unique for each measurement, it's an assumption we rely on
+    const start = Date.now()
+    measurements.forEach((m, ix) => { m.finished_at = start + ix * 1_000 })
 
     await runFraudDetection(1, measurements, sparkRoundDetails)
 

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -139,21 +139,22 @@ describe('preprocess-evaluate integration', () => {
     assert.match(fraudDetectionDuration, /^\d+i/)
     assert.match(setScoresDuration, /^\d+i/)
     assert.deepStrictEqual(evaluateStats, {
-      honest_measurements: '14799i',
-      measurements_DUP_INET_GROUP: '490i',
+      honest_measurements: '7706i',
+      measurements_DUP_INET_GROUP: '160i',
       measurements_INVALID_TASK: '294i',
-      measurements_OK: '14799i',
-      measurements_TOO_MANY_TASKS: '306i',
+      measurements_OK: '7706i',
+      measurements_TOO_MANY_TASKS: '7729i',
       round_index: `${MERIDIAN_ROUND}i`,
       total_measurements: '15889i',
       total_nodes: '11671i',
-      total_participants: '3056i'
+      total_participants: '2356i'
     })
 
     const { fields: retrievalStatsHonest } = assertRecordedTelemetryPoint(telemetry, 'retrieval_stats_honest')
+    debugDumpData('retrievalStatsHonest', retrievalStatsHonest)
     assert.deepStrictEqual(retrievalStatsHonest, {
       car_size_max: '1674i',
-      car_size_mean: '243i',
+      car_size_mean: '245i',
       car_size_min: '151i',
       car_size_p1: '151i',
       car_size_p10: '152i',
@@ -162,47 +163,47 @@ describe('preprocess-evaluate integration', () => {
       car_size_p90: '164i',
       car_size_p95: '871i',
       car_size_p99: '1674i',
-      download_bandwidth: '83612i',
-      duration_max: '53508i',
-      duration_mean: '6219i',
+      download_bandwidth: '33630i',
+      duration_max: '43692i',
+      duration_mean: '5481i',
       duration_min: '391i',
-      duration_p1: '671i',
-      duration_p10: '947i',
-      duration_p5: '855i',
-      duration_p50: '2880i',
-      duration_p90: '17908i',
-      duration_p95: '30556i',
-      duration_p99: '33461i',
-      indexer_rate_ERROR_404: '0.7755253733360362',
-      indexer_rate_ERROR_FETCH: '0.00013514426650449354',
-      indexer_rate_HTTP_NOT_ADVERTISED: '0.08689776336238936',
-      indexer_rate_NO_VALID_ADVERTISEMENT: '0.12372457598486385',
-      indexer_rate_OK: '0.013717143050206096',
+      duration_p1: '726i',
+      duration_p10: '945i',
+      duration_p5: '880i',
+      duration_p50: '2743i',
+      duration_p90: '13950i',
+      duration_p95: '23007i',
+      duration_p99: '33120i',
+      indexer_rate_ERROR_404: '0.8162470801972489',
+      indexer_rate_ERROR_FETCH: '0.00012976901116013495',
+      indexer_rate_HTTP_NOT_ADVERTISED: '0.07409810537243706',
+      indexer_rate_NO_VALID_ADVERTISEMENT: '0.10005190760446406',
+      indexer_rate_OK: '0.009473137814689852',
       inet_groups: '1459i',
-      measurements: '14799i',
-      nano_score_per_inet_group_max: '16149740i',
+      measurements: '7706i',
+      nano_score_per_inet_group_max: '1946535i',
       nano_score_per_inet_group_mean: '685400i',
-      nano_score_per_inet_group_min: '67572i',
-      nano_score_per_inet_group_p10: '67572i',
-      nano_score_per_inet_group_p1: '67572i',
-      nano_score_per_inet_group_p50: '135144i',
-      nano_score_per_inet_group_p5: '67572i',
-      nano_score_per_inet_group_p90: '1554159i',
-      nano_score_per_inet_group_p95: '3047503i',
-      nano_score_per_inet_group_p99: '8474897i',
-      participants: '3055i',
-      rate_of_deals_advertising_http: '0.02',
-      result_rate_BAD_GATEWAY: '0.06574768565443612',
+      nano_score_per_inet_group_min: '129769i',
+      nano_score_per_inet_group_p1: '129769i',
+      nano_score_per_inet_group_p10: '129769i',
+      nano_score_per_inet_group_p5: '129769i',
+      nano_score_per_inet_group_p50: '259538i',
+      nano_score_per_inet_group_p90: '1946535i',
+      nano_score_per_inet_group_p95: '1946535i',
+      nano_score_per_inet_group_p99: '1946535i',
+      participants: '2355i',
+      rate_of_deals_advertising_http: '0.018',
+      result_rate_BAD_GATEWAY: '0.055281598754217495',
       result_rate_CAR_TOO_LARGE: '0',
       result_rate_GATEWAY_TIMEOUT: '0',
-      result_rate_IPNI_ERROR_404: '0.7755253733360362',
-      result_rate_IPNI_ERROR_FETCH: '0.00013514426650449354',
-      result_rate_IPNI_NO_VALID_ADVERTISEMENT: '0.12372457598486385',
-      result_rate_OK: '0.02324481383877289',
-      result_rate_TIMEOUT: '0.01087911345361173',
-      result_rate_UNKNOWN_ERROR: '0.0007432934657747145',
+      result_rate_IPNI_ERROR_404: '0.8162470801972489',
+      result_rate_IPNI_ERROR_FETCH: '0.00012976901116013495',
+      result_rate_IPNI_NO_VALID_ADVERTISEMENT: '0.10005190760446406',
+      result_rate_OK: '0.01777835452893849',
+      result_rate_TIMEOUT: '0.009862444848170258',
+      result_rate_UNKNOWN_ERROR: '0.0006488450558006748',
       round_index: `${MERIDIAN_ROUND}i`,
-      success_rate: '0.02324481383877289',
+      success_rate: '0.01777835452893849',
       tasks_per_node_max: '15i',
       tasks_per_node_mean: '1i',
       tasks_per_node_min: '1i',
@@ -212,21 +213,22 @@ describe('preprocess-evaluate integration', () => {
       tasks_per_node_p50: '1i',
       tasks_per_node_p90: '2i',
       tasks_per_node_p95: '3i',
-      tasks_per_node_p99: '5i',
+      tasks_per_node_p99: '6i',
       ttfb_max: '43169i',
-      ttfb_mean: '4823i',
+      ttfb_mean: '4050i',
       ttfb_min: '391i',
-      ttfb_p1: '668i',
-      ttfb_p10: '1154i',
-      ttfb_p5: '850i',
-      ttfb_p50: '2890i',
-      ttfb_p90: '10917i',
-      ttfb_p95: '16031i',
-      ttfb_p99: '27253i',
+      ttfb_p1: '604i',
+      ttfb_p10: '1131i',
+      ttfb_p5: '843i',
+      ttfb_p50: '2707i',
+      ttfb_p90: '6763i',
+      ttfb_p95: '11607i',
+      ttfb_p99: '23513i',
       unique_tasks: '1000i'
     })
 
     const { fields: retrievalStatsAll } = assertRecordedTelemetryPoint(telemetry, 'retrieval_stats_all')
+    debugDumpData('retrievalStatsAll', retrievalStatsAll)
     assert.deepStrictEqual(retrievalStatsAll, {
       car_size_max: '1674i',
       car_size_mean: '240i',
@@ -256,16 +258,16 @@ describe('preprocess-evaluate integration', () => {
       indexer_rate_OK: '0.013405500660834539',
       inet_groups: '1459i',
       measurements: '15889i',
-      nano_score_per_inet_group_max: '16149740i',
+      nano_score_per_inet_group_max: '1946535i',
       nano_score_per_inet_group_mean: '685400i',
-      nano_score_per_inet_group_min: '67572i',
-      nano_score_per_inet_group_p10: '67572i',
-      nano_score_per_inet_group_p1: '67572i',
-      nano_score_per_inet_group_p50: '135144i',
-      nano_score_per_inet_group_p5: '67572i',
-      nano_score_per_inet_group_p90: '1554159i',
-      nano_score_per_inet_group_p95: '3047503i',
-      nano_score_per_inet_group_p99: '8474897i',
+      nano_score_per_inet_group_min: '129769i',
+      nano_score_per_inet_group_p1: '129769i',
+      nano_score_per_inet_group_p10: '129769i',
+      nano_score_per_inet_group_p5: '129769i',
+      nano_score_per_inet_group_p50: '259538i',
+      nano_score_per_inet_group_p90: '1946535i',
+      nano_score_per_inet_group_p95: '1946535i',
+      nano_score_per_inet_group_p99: '1946535i',
       participants: '3091i',
       rate_of_deals_advertising_http: '0.015910898965791568',
       result_rate_BAD_GATEWAY: '0.0644471017685191',
@@ -303,6 +305,7 @@ describe('preprocess-evaluate integration', () => {
     })
 
     const { fields: committeesStats } = assertRecordedTelemetryPoint(telemetry, 'committees')
+    debugDumpData('committeesStats', committeesStats)
     assert.deepStrictEqual(committeesStats, {
       measurements_max: '31i',
       measurements_mean: '12i',
@@ -334,7 +337,7 @@ describe('preprocess-evaluate integration', () => {
       participants_p90: '18i',
       participants_p95: '20i',
       participants_p99: '23i',
-      round_index: '3602i',
+      round_index: `${MERIDIAN_ROUND}i`,
       subnets_max: '29i',
       subnets_mean: '12i',
       subnets_min: '1i',
@@ -352,50 +355,65 @@ describe('preprocess-evaluate integration', () => {
     // Asserting all 8k participants & their scores would be too much code to have here.
     // Let's check a smaller number of participants & their scores as a smoke test.
 
+    debugDumpData('participantAddresses.slice(0, 20)', Array.from(ieContractWithSigner.participantAddresses.slice(0, 20)))
     assert.deepStrictEqual(ieContractWithSigner.participantAddresses.slice(0, 20), [
-      '0xE02314Be6EDf3ed2F5510FaEf13DDD6814Ff61Ec',
-      '0x47faa92Ee17318B4c39121198369C8164d0A6f5f',
-      '0x35c443AFd895fFB2B769A3416191a9EA500f946A',
-      '0x538F79A3CfB9714c456a08E0575081cF98b916b4',
-      '0x67a7181e2EaC9eFE30EF08B80655f175F89db190',
-      '0xe65Dc466cdE87Fe7d786A14D18c10807242A391c',
-      '0xba8609c9c4481bfb1b09db2f7297a92f43d5bf0e',
-      '0x88D69BF4f948307a6D9C86556D6C37D77982b33F',
-      '0x077D5C04F7CddfeF87e236e4336115503099dBbb',
-      '0x898435cB497392dCFC9661616a297aaE6Bdf8771',
-      '0x6C5DF43ffb05d09b29260d084AB58ba443870622',
       '0xc79e3159817B9A3D875C1d27561500337c6888D3',
       '0x83A2140703df40EAafb89F5c7751BF28e36b6320',
+      '0x5AbB29D74fBA3770De4f94EE916B705C09A61d1E',
       '0xF1332F0C302Cb1BB8Eeac99b6f6dcbDe3AcD8F2f',
       '0xAAE01930Ebb5691fcbCb2ff55d757A392a732822',
       '0x1231CC8E61dEfD317fB522D111cD1b32a559ec13',
-      '0x8d5b8366EC66fe3f8F46ad8c75065Dd325915eE6',
+      '0x1305cd955586Cc40ae67Cd3eF1da6a97788bFfEa',
+      '0x5414435240788bEa919aB210AF07F563eb40B2dd',
       '0x2c7AC351c658bAdCE61359392e9566A7569fd23D',
       '0x5d317728639fdD3083b962Cc579dC4D2E3230Bf1',
-      '0x4CCEA97c1AE6eDd77d954003db07f1c6DfF67902'
+      '0x4CCEA97c1AE6eDd77d954003db07f1c6DfF67902',
+      '0xC4C961D3Ffd9192780907aEE33603dB9E2F975B3',
+      '0x8Fe8FAe6FfBB6870eB8E208b5bd2c0B0d09e17F3',
+      '0x5827c0e02E0FD1191FABb5b1A8Aa5FFB747c6eF9',
+      '0x19ea9e9f4C2AE3B90501D6ED6B90Cd4f1a203b1C',
+      '0x488BBeb02dBcBa7667Ae003Ac30795a65d015827',
+      '0xd88691B0d63c3d4Ce11098BD38d59BD3B27567ec',
+      '0x2cE5644f2E470b664e0B87dEa744e9EC5e448180',
+      '0x0f553C9DDe2ba1d1d18a0669653EAB980A3928aA',
+      '0x0CDB197fb9eA0b7927c6f43Aa0bCE60F60814Eb4'
     ])
 
+    debug('scores.slice(0, 20) [%s]', ieContractWithSigner.scores.slice(0, 20).map(it => `\n${it}n,`).join('') + '\n')
     assert.deepStrictEqual(ieContractWithSigner.scores.slice(0, 20), [
-      67572133252n,
-      67572133252n,
-      135144266504n,
-      67572133252n,
-      67572133252n,
-      67572133252n,
-      67572133252n,
-      67572133252n,
-      67572133252n,
-      67572133252n,
-      135144266504n,
-      67572133252n,
-      67572133252n,
-      67572133252n,
-      67572133252n,
-      67572133252n,
-      67572133252n,
-      67572133252n,
-      67572133252n,
-      67572133252n
+      129769011160n,
+      129769011160n,
+      129769011160n,
+      129769011160n,
+      129769011160n,
+      129769011160n,
+      129769011160n,
+      129769011160n,
+      129769011160n,
+      129769011160n,
+      129769011160n,
+      129769011160n,
+      129769011160n,
+      259538022320n,
+      129769011160n,
+      129769011160n,
+      129769011160n,
+      129769011160n,
+      129769011160n,
+      129769011160n
     ])
   })
 })
+
+const debugDumpData = (name, data) => {
+  if (Array.isArray(data)) {
+    debug(name, JSON.stringify(data, null, 2))
+    return
+  }
+
+  const keys = Object.keys(data)
+  keys.sort()
+  const sorted = {}
+  for (const k of keys) sorted[k] = data[k]
+  debug(name, JSON.stringify(sorted, null, 2))
+}


### PR DESCRIPTION
Rework the rewards awarded to each inet-group so that:
- We reward at most `maxTasksPerNode` measurements in each inet group, regardless of which task they belong to
- We reward only the first measurement for each task 

Links:
- https://github.com/filecoin-station/spark-evaluate/pull/223
- https://github.com/filecoin-station/spark-evaluate/pull/226
