### PR TITLE
feat: remove "inet group success rate" stats

### DIFF
--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -69,7 +69,7 @@ export const evaluate = async ({
 
   const started = Date.now()
 
-  const fraudDetectionStats = await runFraudDetection(roundIndex, measurements, sparkRoundDetails)
+  await runFraudDetection(roundIndex, measurements, sparkRoundDetails)
   const honestMeasurements = measurements.filter(m => m.fraudAssessment === 'OK')
 
   // Calculate reward shares
@@ -114,11 +114,6 @@ export const evaluate = async ({
     measurements.length,
     honestMeasurements.length,
     fraudAssessments
-  )
-  logger.log(
-    'EVALUATE ROUND %s: Success rate of winning per-inet-group task reward:\n%o',
-    roundIndex,
-    fraudDetectionStats.groupWinning
   )
 
   const fraudDetectionDuration = Date.now() - started
@@ -178,18 +173,6 @@ export const evaluate = async ({
     for (const [type, count] of Object.entries(fraudAssessments)) {
       point.intField(`measurements_${type}`, count)
     }
-
-    for (const [key, value] of Object.entries(fraudDetectionStats.groupWinning)) {
-      // At some point, we had a bug in the evaluation pipeline which caused some group winning
-      // rates to be undefined or NaN. InfluxDB client rejected such values, which triggered
-      // unhandled error. Let's avoid that situation by ignoring such data points.
-      try {
-        point.floatField(`group_winning_${key}`, value)
-      } catch (err) {
-        console.error(err)
-        Sentry.captureException(err, { extra: { roundIndex } })
-      }
-    }
   })
 
   const ignoredErrors = []
@@ -242,7 +225,6 @@ export const evaluate = async ({
  * @param {bigint} roundIndex
  * @param {import('./preprocess.js').Measurement[]} measurements
  * @param {import('./typings.js').RoundDetails} sparkRoundDetails
- * @returns {Promise<import('./typings.js').FraudDetectionStats>}
  */
 export const runFraudDetection = async (roundIndex, measurements, sparkRoundDetails) => {
   //
@@ -357,83 +339,6 @@ export const runFraudDetection = async (roundIndex, measurements, sparkRoundDeta
         m)
     }
   }
-
-  return {
-    groupWinning: calculateInetGroupSuccessRates(taskGroups)
-  }
-}
-
-/**
- * For each participant, calculate how many valid measurements were rewarded or
- * rejected by our inet_group algorithm. Multiple measurements submitted for the same task
- * are considered as one measurement.
- *
- * @param {Map<string, import('./preprocess.js').Measurement[]>} taskGroups
- * @returns {import('./typings.js').GroupWinningStats}
- */
-const calculateInetGroupSuccessRates = (taskGroups) => {
-  debug('calculateInetGroupSuccessRates')
-
-  /** @type {Map<string, {won: number, lost: number}>} */
-  const participantStats = new Map()
-
-  for (const groupMeasurements of taskGroups.values()) {
-    debug(
-      '  measurements for inet_group=%s cid=%s minerId=%s',
-      groupMeasurements[0].inet_group,
-      groupMeasurements[0].cid,
-      groupMeasurements[0].minerId
-    )
-    // First, find participants that submitted some valid measurements for this task
-    // and find out whether they were rewarded or not
-
-    /** @type {Map<string, boolean>} */
-    const taskParticipants = new Map()
-    for (const m of groupMeasurements) {
-      if (m.fraudAssessment === 'OK') {
-        taskParticipants.set(m.participantAddress, true)
-        debug('    %s -> won', m.participantAddress)
-      } else if (m.fraudAssessment === 'DUP_INET_GROUP') {
-        if (!taskParticipants.has(m.participantAddress)) {
-          taskParticipants.set(m.participantAddress, false)
-          debug('    %s -> lost', m.participantAddress)
-        } else {
-          debug('    %s -> skip (redundant)', m.participantAddress)
-        }
-      }
-    }
-
-    // Next, update each participant's winning score
-    for (const [participantAddress, wasPickedForReward] of taskParticipants.entries()) {
-      let s = participantStats.get(participantAddress)
-      if (!s) {
-        s = { won: 0, lost: 0 }
-        participantStats.set(participantAddress, s)
-      }
-
-      s[wasPickedForReward ? 'won' : 'lost']++
-    }
-  }
-
-  if (!participantStats.size) {
-    console.log('This round has no participants with OK or DUP_INET_GROUP measurements.')
-    return { min: 1, mean: 1, max: 1 }
-  }
-
-  // Finally, calculate the aggregate statistics
-  const result = { min: 1.0, max: 0.0, mean: undefined }
-  let sum = 0
-  for (const [pa, s] of participantStats.entries()) {
-    const successRate = s.won / (s.won + s.lost)
-    if (successRate < result.min) result.min = successRate
-    if (successRate > result.max) result.max = successRate
-    sum += successRate
-    debug('Winning rate for %s: won %s lost %s rate %s', pa, s.won, s.lost, successRate)
-  }
-  result.mean = sum / participantStats.size
-
-  debug('Winning rates stats: %o', result)
-  return result
 }
 
 /**

--- a/lib/typings.d.ts
+++ b/lib/typings.d.ts
@@ -74,14 +74,4 @@ export interface RawMeasurement {
   indexer_result: string | undefined | null;
 }
 
-export interface GroupWinningStats {
-  min: number;
-  max: number;
-  mean: number;
-}
-
-export interface FraudDetectionStats {
-  groupWinning: GroupWinningStats
-}
-
 export type CreatePgClient = () => Promise<import('pg').Client>;

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -3,7 +3,7 @@ import { Point } from '../lib/telemetry.js'
 import assert from 'node:assert'
 import createDebug from 'debug'
 import { VALID_MEASUREMENT, VALID_TASK, today } from './helpers/test-data.js'
-import { assertPointFieldValue } from './helpers/assertions.js'
+import { assertPointFieldValue, assertRecordedTelemetryPoint } from './helpers/assertions.js'
 import { RoundData } from '../lib/round.js'
 import { DATABASE_URL } from '../lib/config.js'
 import pg from 'pg'
@@ -127,9 +127,6 @@ describe('evaluate', () => {
     assert(!!point,
       `No telemetry point "evaluate" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
 
-    assertPointFieldValue(point, 'group_winning_min', '1')
-    assertPointFieldValue(point, 'group_winning_mean', '1')
-    assertPointFieldValue(point, 'group_winning_max', '1')
     // TODO: assert point fields
 
     point = telemetry.find(p => p.name === 'retrieval_stats_honest')
@@ -221,12 +218,9 @@ describe('evaluate', () => {
     )
     assert.strictEqual(setScoresCalls[0].scores.length, 2)
 
-    const point = telemetry.find(p => p.name === 'evaluate')
+    const point = assertRecordedTelemetryPoint(telemetry, 'evaluate')
     assert(!!point,
       `No telemetry point "evaluate" was recorded. Actual points: ${JSON.stringify(telemetry.map(p => p.name))}`)
-    assertPointFieldValue(point, 'group_winning_min', '1')
-    assertPointFieldValue(point, 'group_winning_mean', '1')
-    assertPointFieldValue(point, 'group_winning_max', '1')
 
     assertPointFieldValue(point, 'total_nodes', '3i')
   })
@@ -364,18 +358,11 @@ describe('fraud detection', () => {
       { ...VALID_MEASUREMENT }
     ]
 
-    const stats = await runFraudDetection(1, measurements, sparkRoundDetails)
+    await runFraudDetection(1, measurements, sparkRoundDetails)
     assert.deepStrictEqual(
       measurements.map(m => m.fraudAssessment),
       ['OK', 'DUP_INET_GROUP']
     )
-    assert.deepStrictEqual(stats, {
-      groupWinning: {
-        min: 1.0,
-        max: 1.0,
-        mean: 1.0
-      }
-    })
   })
 
   it('picks different inet-group member to reward for each task', async () => {
@@ -416,7 +403,7 @@ describe('fraud detection', () => {
       }
     }
 
-    const stats = await runFraudDetection(1, measurements, sparkRoundDetails)
+    await runFraudDetection(1, measurements, sparkRoundDetails)
     assert.deepStrictEqual(
       measurements.map(m => `${m.participantAddress}::${m.fraudAssessment}`),
       [
@@ -430,13 +417,6 @@ describe('fraud detection', () => {
         'pa2::OK'
       ]
     )
-    assert.deepStrictEqual(stats, {
-      groupWinning: {
-        min: 0.5,
-        max: 0.5,
-        mean: 0.5
-      }
-    })
   })
 
   it('calculates aggregate stats of participant group-winning rate', async () => {
@@ -493,7 +473,7 @@ describe('fraud detection', () => {
       }
     }
 
-    const stats = await runFraudDetection(1, measurements, sparkRoundDetails)
+    await runFraudDetection(1, measurements, sparkRoundDetails)
     assert.deepStrictEqual(
       measurements.map(m => `${m.participantAddress}::${m.fraudAssessment}`),
       [
@@ -510,13 +490,6 @@ describe('fraud detection', () => {
         'pa3::OK'
       ]
     )
-    assert.deepStrictEqual(stats, {
-      groupWinning: {
-        min: 0.3333333333333333,
-        max: 1.0,
-        mean: 0.6666666666666666
-      }
-    })
   })
 
   it('rejects measurements above maxTasksPerNode', async () => {

--- a/test/helpers/assertions.js
+++ b/test/helpers/assertions.js
@@ -1,6 +1,8 @@
 import assert from 'node:assert'
 
 /**
+ * @param {import('../../lib/telemetry').Point[]} recordings
+ * @param {string} name
  * @returns {import('../../lib/telemetry').Point}
  */
 export const assertRecordedTelemetryPoint = (recordings, name) => {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -139,9 +139,6 @@ describe('preprocess-evaluate integration', () => {
     assert.match(fraudDetectionDuration, /^\d+i/)
     assert.match(setScoresDuration, /^\d+i/)
     assert.deepStrictEqual(evaluateStats, {
-      group_winning_max: '1',
-      group_winning_mean: '0.9688518372637581',
-      group_winning_min: '0',
       honest_measurements: '14799i',
       measurements_DUP_INET_GROUP: '490i',
       measurements_INVALID_TASK: '294i',


### PR DESCRIPTION
These stats are difficult to understand. Thefeore, we haven't been using them for a while now.

My work on fixing the per-inet-group reward selection in #225 would require us to significantly rework the way how to calculate these stats. I decided it's not worth the effort.

As of #223, we are recording slightly different stats about per-inet-group rewards, so we will still have some visibility into this area.