### PR TITLE
feat: upgrade Node.js to v20.13.1 (latest LTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1
 
 # Adjust NODE_VERSION as desired
-ARG NODE_VERSION=20.3.1
+ARG NODE_VERSION=20.13.1
 FROM node:${NODE_VERSION}-slim as base
 
 LABEL fly_launch_runtime="NodeJS"
@@ -19,7 +19,7 @@ FROM base as build
 
 # Install packages needed to build node modules
 RUN apt-get update -qq && \
-    apt-get install -y python-is-python3 pkg-config build-essential 
+    apt-get install -y python-is-python3 pkg-config build-essential
 
 # Install node modules
 COPY --link package.json package-lock.json .


### PR DESCRIPTION
Get rid of the following warning printed by Sentry:

```
[Sentry] You are using Node.js in ESM mode ("import syntax"). The Sentry
Node.js SDK is not compatible with ESM in Node.js versions before
18.19.0 or before 20.6.0. Please either build your application with
CommonJS ("require() syntax"), or use version 7.x of the Sentry Node.js
SDK.
```
