### PR TITLE
fix: advance round before waiting for preprocess

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,15 +82,15 @@ export const startEvaluate = async ({
       return
     }
 
+    rounds.previous = rounds.current
+    rounds.current = new RoundData(roundIndex)
+
     // TODO: Fix this properly and implement a signalling mechanism allowing the "preprocess" step
     // to notify the "evaluate" when the preprocessing is done, so that we don't have to use a timer
     // here. See also https://github.com/filecoin-station/spark-evaluate/issues/64
     console.log(`Sleeping for ${EVALUATE_DELAY}ms before evaluating the round to let the preprocess step finish for the last batch of measurements`)
     await timers.setTimeout(EVALUATE_DELAY)
     console.log(`Now evaluating the round ${roundIndex}`)
-
-    rounds.previous = rounds.current
-    rounds.current = new RoundData(roundIndex)
 
     // Evaluate previous round
     evaluate({


### PR DESCRIPTION
Fix the regression introduced by #224 where the first measurements batch added to a new round triggers the following error:

```
Round index mismatch: 7386 !== 7387
```

Sentry issue:
https://space-meridian.sentry.io/issues/5385606165/?project=4505906069766144

