### PR TITLE
fix: handle round mismatch on MeasurementsAdded

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,10 +37,17 @@ export const startEvaluate = async ({
     if (!rounds.current) {
       rounds.current = new RoundData(roundIndex)
     } else if (rounds.current.index !== roundIndex) {
-      // This should never happen
-      throw new Error(
-        `Round index mismatch: ${rounds.current.index} !== ${roundIndex}`
-      )
+      // This occassionally happens because of a race condition between onMeasurementsAdded
+      // and onRoundStart event handlers. We should eventually fix it.
+      const msg = 'Round index mismatch when processing MeasurementsAdded event'
+      const details = {
+        currentRoundIndex: rounds.current.index,
+        eventRoundIndex: roundIndex,
+        measurementsCid: cid
+      }
+      console.error(msg, details)
+      Sentry.captureException(new Error(msg), { extra: details })
+      return
     }
 
     console.log('Event: MeasurementsAdded', { roundIndex })
@@ -84,6 +91,7 @@ export const startEvaluate = async ({
 
     rounds.previous = rounds.current
     rounds.current = new RoundData(roundIndex)
+    console.log('Advanced the current round to %s', roundIndex)
 
     // TODO: Fix this properly and implement a signalling mechanism allowing the "preprocess" step
     // to notify the "evaluate" when the preprocessing is done, so that we don't have to use a timer

--- a/index.js
+++ b/index.js
@@ -38,7 +38,8 @@ export const startEvaluate = async ({
       rounds.current = new RoundData(roundIndex)
     } else if (rounds.current.index !== roundIndex) {
       // This occassionally happens because of a race condition between onMeasurementsAdded
-      // and onRoundStart event handlers. We should eventually fix it.
+      // and onRoundStart event handlers.
+      // See https://github.com/filecoin-station/spark-evaluate/issues/233
       const msg = 'Round index mismatch when processing MeasurementsAdded event'
       const details = {
         currentRoundIndex: rounds.current.index,


### PR DESCRIPTION
Rework the handler to report the error to stderr & Sentry and ignore the event instead of crashing the process.

Related:
- https://github.com/filecoin-station/spark-evaluate/issues/64
- #224
- #230

Sentry issue:
- https://space-meridian.sentry.io/issues/5385606165/
- plus many more, because each error had a unique message due to the included round index
