### PR TITLE
feat: bin/fetch-recent-miner-measurements.js

### DIFF
--- a/bin/fetch-recent-miner-measurements.js
+++ b/bin/fetch-recent-miner-measurements.js
@@ -1,0 +1,193 @@
+// dotenv must be imported before importing anything else
+import 'dotenv/config'
+
+import { Point } from '@influxdata/influxdb-client'
+import * as Sentry from '@sentry/node'
+import createDebug from 'debug'
+import fs, { mkdir, readFile, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import pMap from 'p-map'
+import { IE_CONTRACT_ADDRESS } from '../lib/config.js'
+import { createMeridianContract } from '../lib/ie-contract.js'
+import { fetchMeasurements, preprocess } from '../lib/preprocess.js'
+import { RoundData } from '../lib/round.js'
+
+Sentry.init({
+  dsn: 'https://d0651617f9690c7e9421ab9c949d67a4@o1408530.ingest.sentry.io/4505906069766144',
+  environment: process.env.SENTRY_ENVIRONMENT || 'dry-run',
+  // Performance Monitoring
+  tracesSampleRate: 0.1 // Capture 10% of the transactions
+})
+
+const debug = createDebug('spark:bin')
+
+const cacheDir = path.resolve('.cache')
+await mkdir(cacheDir, { recursive: true })
+
+const [nodePath, selfPath, ...args] = process.argv
+if (args.length === 0 || !args[0].startsWith('0x')) {
+  args.unshift(IE_CONTRACT_ADDRESS)
+}
+const [contractAddress, minerId, blocksToQuery] = args
+
+const USAGE = `
+Usage:
+  ${nodePath} ${selfPath} [contract-address] minerId [blocksToQuery]
+`
+
+if (!contractAddress) {
+  console.error('Missing required argument: contractAddress')
+  console.error(USAGE)
+  process.exit(1)
+}
+
+if (!minerId) {
+  console.error('Missing required argument: minerId')
+  console.error(USAGE)
+  process.exit(1)
+}
+
+if (!minerId.startsWith('f0')) {
+  console.warn('Warning: miner id %s does not start with "f0", is it a valid miner address?', minerId)
+}
+
+await run(contractAddress, minerId, blocksToQuery)
+
+async function run (contractAddress, minerId, blocksToQuery) {
+  console.error('Querying the chain for recent MeasurementsAdded events')
+  const measurementCids = await getRecentMeasurementsAddedEvents(contractAddress, blocksToQuery)
+  console.error(' → found %s events', measurementCids.length)
+
+  console.error('Fetching measurements from IPFS')
+  const roundIndex = 0n
+  const round = new RoundData(roundIndex)
+  await pMap(
+    measurementCids,
+    cid => fetchAndLoadMeasurements(round, cid),
+    { concurrency: os.cpus().length })
+  for (const cid of measurementCids) {
+    await fetchAndLoadMeasurements(round, cid)
+  }
+  console.error(' → fetched %s measurements', round.measurements.length)
+
+  const measurements = round.measurements.filter(m => m.minerId === minerId)
+  console.error('Found %s measurements for miner %s', measurements.length, minerId)
+  if (!measurements.length) return
+
+  console.error('Printing first 10 measurements')
+  /**
+   * @param {import('../lib/preprocess.js').Measurement} m
+   * @returns {string}
+   */
+  const formatMeasurement = (m) => [
+    new Date(m.finished_at).toISOString(),
+    m.cid.padEnd(70),
+    m.retrievalResult
+  ].join(' ')
+  const header = [
+    'Timestamp'.padEnd(new Date().toISOString().length),
+    'CID'.padEnd(70),
+    'RetrievalResult'
+  ].join(' ')
+
+  console.log(header)
+  for (const m of measurements.slice(0, 10)) {
+    console.log(formatMeasurement(m))
+  }
+
+  let outfile = 'measurements-all.ndjson'
+  await writeFile(outfile, round.measurements.map(m => JSON.stringify(m) + '\n').join(''))
+  console.error('Wrote all raw measurements to %s', outfile)
+
+  outfile = `measurements-${minerId}.ndjson`
+  await writeFile(outfile, measurements.map(m => JSON.stringify(m) + '\n').join(''))
+  console.error('Wrote %s raw measurements to %s', minerId, outfile)
+
+  outfile = `measurements-${minerId}.txt`
+  const text = header + '\n' + measurements.map(m => formatMeasurement(m) + '\n').join('')
+  await writeFile(outfile, text)
+  console.error('Wrote human-readable summary for %s to %s', minerId, outfile)
+}
+
+/**
+ * @param {string} contractAddress
+ * @param {number} blocksToQuery
+ * @returns
+ */
+async function getRecentMeasurementsAddedEvents (contractAddress, blocksToQuery = Number.POSITIVE_INFINITY) {
+  const { ieContract } = await createMeridianContract(contractAddress)
+
+  // max look-back period allowed by Glif.io is 2000 blocks (approx 16h40m)
+  // in practice, requests for the last 2000 blocks are usually rejected,
+  // so it's safer to use a slightly smaller number
+  const fromBlock = Math.max(-blocksToQuery, -1990)
+  debug('queryFilter(MeasurementsAdded, %s)', fromBlock)
+  const rawEvents = await ieContract.queryFilter('MeasurementsAdded', fromBlock)
+
+  /** @type {Array<{ cid: string, roundIndex: bigint, sender: string }>} */
+  const events = rawEvents
+    .filter(isEventLog)
+    .map(({ args: [cid, roundIndex, sender] }) => ({ cid, roundIndex, sender }))
+  // console.log('events', events)
+
+  return events.map(e => e.cid)
+}
+
+/**
+ * @param {string} cid
+ */
+async function fetchMeasurementsWithCache (cid) {
+  const pathOfCachedResponse = path.join(cacheDir, cid + '.json')
+  try {
+    const measurements = JSON.parse(await readFile(pathOfCachedResponse, 'utf-8'))
+    debug('Loaded %s from cache', cid)
+    return measurements
+  } catch (err) {
+    if (err.code !== 'ENOENT') console.warn('Cannot read cached measurements:', err)
+  }
+
+  debug('Fetching %s from web3.storage', cid)
+  const measurements = await fetchMeasurements(cid)
+  await writeFile(pathOfCachedResponse, JSON.stringify(measurements))
+  return measurements
+}
+
+/**
+ * @param {RoundData} round
+ * @param {string} cid
+ */
+async function fetchAndLoadMeasurements (round, cid) {
+  try {
+    await preprocess({
+      roundIndex: round.index,
+      round,
+      cid,
+      fetchMeasurements: fetchMeasurementsWithCache,
+      recordTelemetry,
+      logger: { log: debug, error: debug },
+      fetchRetries: 0
+    })
+    console.error(' ✓ %s', cid)
+  } catch (err) {
+    console.error(' × Skipping %s:', cid, err.message)
+  }
+}
+
+/**
+ * @param {import('ethers').Log | import('ethers').EventLog} logOrEventLog
+ * @returns {logOrEventLog is import('ethers').EventLog}
+ */
+function isEventLog (logOrEventLog) {
+  return 'args' in logOrEventLog
+}
+
+/**
+ * @param {string} measurementName
+ * @param {(point: Point) => void} fn
+ */
+function recordTelemetry (measurementName, fn) {
+  const point = new Point(measurementName)
+  fn(point)
+  debug('TELEMETRY %s %o', measurementName, point.fields)
+}

--- a/bin/fetch-recent-miner-measurements.js
+++ b/bin/fetch-recent-miner-measurements.js
@@ -15,7 +15,7 @@ import { fetchMeasurements, preprocess } from '../lib/preprocess.js'
 import { RoundData } from '../lib/round.js'
 
 const {
-  STORE_ALL = false
+  STORE_ALL
 } = process.env
 
 Sentry.init({
@@ -65,7 +65,7 @@ const ALL_MEASUREMENTS_FILE = 'measurements-all.ndjson'
 const MINER_DATA_FILE = `measurements-${minerId}.ndjson`
 const MINER_SUMMARY_FILE = `measurements-${minerId}.txt`
 
-const allMeasurementsWriter = STORE_ALL
+const allMeasurementsWriter = !!STORE_ALL && STORE_ALL.toLowerCase() !== 'false' && STORE_ALL !== '0'
   ? fs.createWriteStream(ALL_MEASUREMENTS_FILE)
   : undefined
 
@@ -78,7 +78,7 @@ const signal = abortController.signal
 process.on('SIGINT', () => abortController.abort(new Error('interrupted')))
 
 try {
-  await pMap(measurementCids, fetchAndProcess, { concurrency: os.cpus().length })
+  await pMap(measurementCids, fetchAndProcess, { concurrency: os.availableParallelism() })
 } catch (err) {
   if (signal.aborted) {
     console.error('Interrupted, exiting. Output files contain partial data.')

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -143,11 +143,14 @@ export const preprocess = async ({
 
 /**
  * @param {string} cid
+ * @param {object} options
+ * @param {AbortSignal} [options.signal]
  * @returns {Promise<import('./typings.js').RawMeasurement[]>}
  */
-export const fetchMeasurements = async cid => {
+export const fetchMeasurements = async (cid, { signal } = {}) => {
   const res = await fetch(
-    `https://${encodeURIComponent(cid)}.ipfs.w3s.link?format=car`
+    `https://${encodeURIComponent(cid)}.ipfs.w3s.link?format=car`,
+    { signal }
   )
   if (!res.ok) {
     const msg = `Cannot fetch measurements ${cid}: ${res.status}\n${await res.text()}`
@@ -171,11 +174,13 @@ export const fetchMeasurements = async cid => {
     }
   })
   for await (const entry of entries) {
+    signal?.throwIfAborted()
     // Depending on size, entries might be packaged as `file` or `raw`
     // https://github.com/web3-storage/w3up/blob/e8bffe2ee0d3a59a977d2c4b7efe425699424e19/packages/upload-client/src/unixfs.js#L11
     if (entry.type === 'file' || entry.type === 'raw') {
       const bufs = []
       for await (const buf of entry.content()) {
+        signal?.throwIfAborted()
         bufs.push(buf)
       }
       return parseMeasurements(Buffer.concat(bufs).toString())

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -159,6 +159,7 @@ export const fetchMeasurements = async (cid, { signal } = {}) => {
   const reader = await CarReader.fromIterable(res.body)
   const entries = exporter(cid, {
     async get (blockCid) {
+      signal?.throwIfAborted()
       // The cast to `any` is a workaround for the following TypeScript error
       // The types of 'toV0()[Symbol.toStringTag]' are incompatible between these types.
       //   Type 'string' is not assignable to type '"CID"'

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -61,6 +61,7 @@ export const preprocess = async ({
     {
       retries: fetchRetries,
       onFailedAttempt: err => {
+        if (!fetchRetries) return
         console.error(err)
         console.error(`Retrying ${cid} ${err.retriesLeft} more times`)
       }
@@ -140,6 +141,10 @@ export const preprocess = async ({
   return validMeasurements
 }
 
+/**
+ * @param {string} cid
+ * @returns {Promise<import('./typings.js').RawMeasurement[]>}
+ */
 export const fetchMeasurements = async cid => {
   const res = await fetch(
     `https://${encodeURIComponent(cid)}.ipfs.w3s.link?format=car`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "spark-evaluate",
+  "name": "evaluate",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -15,6 +15,7 @@
         "ipfs-car": "^1.2.0",
         "ipfs-unixfs-exporter": "^13.5.0",
         "just-percentile": "^4.2.0",
+        "p-map": "^7.0.2",
         "p-retry": "^6.2.0",
         "pg": "^8.11.5",
         "postgrator": "^7.2.0"
@@ -4187,6 +4188,17 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.2.tgz",
+      "integrity": "sha512-z4cYYMMdKHzw4O5UkWJImbZynVIo0lSGTXc7bzB1e/rrDqkgGUNysK/o4bTr+0+xKvvLoTyGqYC4Fgljy9qe1Q==",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "ipfs-car": "^1.2.0",
     "ipfs-unixfs-exporter": "^13.5.0",
     "just-percentile": "^4.2.0",
+    "p-map": "^7.0.2",
     "p-retry": "^6.2.0",
     "pg": "^8.11.5",
     "postgrator": "^7.2.0"


### PR DESCRIPTION
Add a script enabling storage providers to inspect recent Spark measurements for content they are storing.

**Example usage:**

```
node bin/fetch-recent-miner-measurements.js f010479
```

**Example output in measurements-f010479.txt**

```
Timestamp                CID                                                                    Protocol   RetrievalResult
2024-05-24T02:43:14.371Z bafybeigpefr2xxsiigy5witxbmgrg3ok7tnrauz44z3utch5uxakljxlki            http       BAD_GATEWAY
2024-05-24T02:43:19.564Z bafybeigpefr2xxsiigy5witxbmgrg3ok7tnrauz44z3utch5uxakljxlki            http       BAD_GATEWAY
2024-05-24T02:43:28.086Z bafybeigpefr2xxsiigy5witxbmgrg3ok7tnrauz44z3utch5uxakljxlki            http       BAD_GATEWAY
2024-05-24T02:43:30.087Z bafybeigpefr2xxsiigy5witxbmgrg3ok7tnrauz44z3utch5uxakljxlki            http       BAD_GATEWAY
2024-05-24T02:43:33.123Z bafybeigpefr2xxsiigy5witxbmgrg3ok7tnrauz44z3utch5uxakljxlki            http       BAD_GATEWAY
2024-05-24T02:43:39.298Z bafybeigpefr2xxsiigy5witxbmgrg3ok7tnrauz44z3utch5uxakljxlki            http       BAD_GATEWAY
2024-05-24T02:44:29.340Z bafybeigpefr2xxsiigy5witxbmgrg3ok7tnrauz44z3utch5uxakljxlki                       IPNI_ERROR_404
```



**TODO**
- [x] process batches in a streaming way
- [x] lightweight documentation

**Out of scope**
- Dockerfile + a GH Actions step to build & publish docker images

Links:
- https://github.com/filecoin-station/roadmap/issues/107