### PR TITLE
chore: rename DB `spark_stats` to `spark_evaluate`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Set up [PostgreSQL](https://www.postgresql.org/) with default settings:
  - Port: 5432
  - User: _your system user name_
  - Password: _blank_
- - Database: spark_stats
+ - Database: spark_evaluate
 
 Alternatively, set the environment variable `$DATABASE_URL` with
 `postgres://${USER}:${PASS}@${HOST}:${PORT}/${DATABASE}`.
@@ -24,9 +24,16 @@ You can also run the following command to set up the PostgreSQL server via Docke
 docker run -d --name spark-db \
   -e POSTGRES_HOST_AUTH_METHOD=trust \
   -e POSTGRES_USER=$USER \
-  -e POSTGRES_DB=spark_stats \
+  -e POSTGRES_DB=spark_evaluate \
   -p 5432:5432 \
   postgres
+```
+
+If you are sharing the same Postgres instance for multiple projects, run the following
+command to create a new `spark_evaluate` database for this project:
+
+```bash
+psql postgres://localhost:5432/ -c "CREATE DATABASE spark_evaluate;"
 ```
 
 ## Run the tests

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,7 +4,7 @@ const {
   // RPC_URLS = 'https://api.node.glif.io/rpc/v0,https://api.chain.love/rpc/v1',
   RPC_URLS = 'https://api.node.glif.io/rpc/v0',
   GLIF_TOKEN,
-  DATABASE_URL = 'postgres://localhost:5432/spark_stats',
+  DATABASE_URL = 'postgres://localhost:5432/spark_evaluate',
   SPARK_API = 'https://api.filspark.com'
 } = process.env
 


### PR DESCRIPTION
Update the docs and the default config to use the new database name.

- https://github.com/filecoin-station/roadmap/issues/109
