### PR TITLE
feat: fraud detection when fetching miner data

### DIFF
--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -45,7 +45,7 @@ export const createSetScoresBuckets = participants => {
  * @param {any} args.ieContractWithSigner
  * @param {import('./spark-api.js').fetchRoundDetails} args.fetchRoundDetails,
  * @param {import('./typings.js').RecordTelemetryFn} args.recordTelemetry
- * @param {import('./typings.js').CreatePgClient} args.createPgClient
+ * @param {import('./typings.js').CreatePgClient} [args.createPgClient]
  * @param {Pick<Console, 'log' | 'error'>} args.logger
  */
 export const evaluate = async ({
@@ -210,12 +210,14 @@ export const evaluate = async ({
     Sentry.captureException(err)
   }
 
-  try {
-    await updatePublicStats({ createPgClient, honestMeasurements, allMeasurements: measurements })
-  } catch (err) {
-    console.error('Cannot update public stats.', err)
-    ignoredErrors.push(err)
-    Sentry.captureException(err)
+  if (createPgClient) {
+    try {
+      await updatePublicStats({ createPgClient, honestMeasurements, allMeasurements: measurements })
+    } catch (err) {
+      console.error('Cannot update public stats.', err)
+      ignoredErrors.push(err)
+      Sentry.captureException(err)
+    }
   }
 
   return { ignoredErrors }


### PR DESCRIPTION
Improve the script `fetch-recent-miner-measurements.js` to group measurements into rounds and apply fraud detection to reject measurements not contributing to the retrieval success rate score shown by Spark dashboards.

When the env var `KEEP_REJECTED` is set, include both accepted and rejected measurements in the output, and write the `fraudAssesment` field too.

When `KEEP_REJECTED` is not set, only accepted measurements are written and the `fraudAssesment` field is hidden from the user.
