### PR TITLE
feat: show progress in discovering miner measurements

### DIFF
--- a/bin/fetch-recent-miner-measurements.js
+++ b/bin/fetch-recent-miner-measurements.js
@@ -118,7 +118,7 @@ if (signal.aborted) {
   console.error('Interrupted, exiting. Output files contain partial data.')
 }
 
-console.log('Found %s accepted measurements:', resultCounts.total)
+console.log('Found %s accepted measurements.', resultCounts.total)
 for (const [r, c] of Object.entries(resultCounts)) {
   if (r === 'total') continue
   console.log('  %s %s (%s%)',
@@ -244,6 +244,7 @@ async function processRound (roundIndex, measurementCids, resultCounts) {
       .map(m => formatMeasurement(m, { includeFraudAssesment: keepRejected }) + '\n')
       .join('')
   )
+  console.error(' → added %s new measurements from this round', minerMeasurements.length)
 }
 
 /**


### PR DESCRIPTION
The script `bin/fetch-recent-miner-measurements.js` takes very long to complete. Usually, I abort it after collecting enough measurements.

This change adds a log message with the number of miner measurements found in each round. This makes it easier to know when we have collected enough measurements and can abort the script.
