### PR TITLE
feat: index daily_stations by day

### DIFF
--- a/migrations/011.do.daily-stations-idx-day.sql
+++ b/migrations/011.do.daily-stations-idx-day.sql
@@ -1,0 +1,1 @@
+CREATE INDEX daily_stations_day ON daily_stations (day);


### PR DESCRIPTION
Speed up spark-stats queries, they always filter by a date range.

Before - 7.2 seconds:

```
 ->  Parallel Seq Scan on daily_stations  (cost=0.00..899791.13 rows=2746355 width=144) (actual time=273.312..7516.967 rows=2091389 loops=3)
       Filter: (day = date((now() - '1 day'::interval)))
       Rows Removed by Filter: 8091296
```

After - 0.8 seconds:

```
 ->  Parallel Index Scan using daily_stations_day on daily_stations  (cost=0.45..283087.78 rows=2746355 width=144) (actual time=143.526..988.537 rows=2091389 loops=3)
       Index Cond: (day = date((now() - '1 day'::interval)))
```

I tested various combinations of indexed and included columns. The simplest option - index on the date value only - is performing best.

Links:
- https://github.com/filecoin-station/spark-stats/pull/164
