### PR TITLE
fix: error log format on score tx errors

### DIFF
--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -154,7 +154,7 @@ export const evaluate = async ({
         buckets.length
       )
     } catch (err) {
-      logger.error('CANNOT SUBMIT SCORES FOR ROUND %S (CALL %s/%s): %s',
+      logger.error('CANNOT SUBMIT SCORES FOR ROUND %s (CALL %s/%s): %s',
         roundIndex,
         Number(bucketIndex) + 1,
         buckets.length,


### PR DESCRIPTION
I noticed the error log has incorrect format:

```
CANNOT SUBMIT SCORES FOR ROUND %S (CALL 12059n/4): 11 Error: (...)
```

The problem is that `%S` is not recognized as a formatting directive.

This commit fixes the log format to use `%s` instead.
