### PR TITLE
feat: add more fields to Measurements object

### DIFF
--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -33,8 +33,11 @@ export class Measurement {
     this.first_byte_at = parseDateTime(m.first_byte_at)
     this.end_at = parseDateTime(m.end_at)
     this.status_code = m.status_code
+    this.timeout = m.timeout
     this.indexerResult = pointerize(m.indexer_result)
     this.stationId = pointerize(m.station_id)
+    this.carChecksum = pointerize(m.car_checksum)
+    this.carTooLarge = m.car_too_large
   }
 }
 

--- a/lib/typings.d.ts
+++ b/lib/typings.d.ts
@@ -81,6 +81,7 @@ export interface RawMeasurement {
   timeout: boolean;
   byte_length: number;
   car_too_large: boolean;
+  car_checksum: string;
   indexer_result: string | undefined | null;
 }
 

--- a/test/helpers/test-data.js
+++ b/test/helpers/test-data.js
@@ -27,7 +27,10 @@ export const VALID_MEASUREMENT = {
   first_byte_at: new Date('2023-11-01T09:00:01.000Z').getTime(),
   end_at: new Date('2023-11-01T09:00:02.000Z').getTime(),
   finished_at: new Date('2023-11-01T09:00:10.000Z').getTime(),
+  timeout: false,
   byte_length: 1024,
+  carChecksum: 'some-car-checksum',
+  carTooLarge: false,
   retrievalResult: 'OK',
   indexerResult: 'OK',
   fraudAssessment: null


### PR DESCRIPTION
The following fields are present in raw measurements stored in
web3.storage, let's add them to our Measurements object:

-  timeout
-  car_checksum
-  car_too_large

Links:
- https://github.com/space-meridian/roadmap/issues/59
