### PR TITLE
fix: include minority results in RSR calculation

### DIFF
--- a/lib/public-stats.js
+++ b/lib/public-stats.js
@@ -18,12 +18,15 @@ const debug = createDebug('spark:public-stats')
 export const updatePublicStats = async ({ createPgClient, committees, honestMeasurements, allMeasurements }) => {
   /** @type {Map<string, {total: number, successful: number}>} */
   const minerRetrievalStats = new Map()
-  for (const m of honestMeasurements) {
-    const minerId = m.minerId
-    const retrievalStats = minerRetrievalStats.get(minerId) ?? { total: 0, successful: 0 }
-    retrievalStats.total++
-    if (m.retrievalResult === 'OK') retrievalStats.successful++
-    minerRetrievalStats.set(minerId, retrievalStats)
+  for (const c of committees) {
+    // IMPORTANT: include minority results in the calculation
+    for (const m of c.measurements) {
+      const minerId = m.minerId
+      const retrievalStats = minerRetrievalStats.get(minerId) ?? { total: 0, successful: 0 }
+      retrievalStats.total++
+      if (m.retrievalResult === 'OK') retrievalStats.successful++
+      minerRetrievalStats.set(minerId, retrievalStats)
+    }
   }
 
   const pgClient = await createPgClient()

--- a/test/public-stats.test.js
+++ b/test/public-stats.test.js
@@ -86,7 +86,6 @@ describe('public-stats', () => {
       const allMeasurements = honestMeasurements
       let committees = buildEvaluatedCommitteesFromMeasurements(honestMeasurements)
 
-
       await updatePublicStats({ createPgClient, committees, honestMeasurements, allMeasurements })
 
       const { rows: created } = await pgClient.query(


### PR DESCRIPTION
Fix a regression introduced by 49252980 (#304).

With the recently introduced “committees & majorities”, measurements that don’t agree with the majority are rejected. As a result, the code calculating RSR will receive only majority measurements, it will see that either a) all accepted measurements say the deal is retrievable or b) all accepted measurements say the deal is not retrievable. As a result, the RSR is heavily influenced by how many measurements were collected for each deal.

For example, let’s say an SP has one deal that’s retrievable and another that is not. Now consider two cases:

1. The task testing the retrievable deal produces 100 retrieval requests (accepted measurements) while the task testing the non-retrievable deal produces 50 retrieval requests (accepted measurements).

   The RSR is 100 / (100 + 50) = 66%.

2. The task testing the retrievable deal produces 50 retrieval requests (accepted measurements) while the task testing the non-retrievable deal produces 100 retrieval requests (accepted measurements).

   The RSR is 50 / (100 + 50) = 33$.

This commit fixes the problem by changing the implementation of `updatePublicStats` to iterate over all measurements assigned to all committees. This way we include all measurements in the calculation: minority measurements, measurements where no majority was found, measurements belonging to committees that are too small.

Links:
- https://github.com/space-meridian/roadmap/issues/59
- #304
