### PR TITLE
Add use `NonceManager` to prevent non-serial nonce errors

### DIFF
--- a/bin/spark-evaluate.js
+++ b/bin/spark-evaluate.js
@@ -30,10 +30,11 @@ await migrateWithPgConfig({ connectionString: DATABASE_URL })
 
 const { ieContract, provider } = await createMeridianContract()
 
-const signer = ethers.Wallet.fromPhrase(WALLET_SEED, provider)
-const walletDelegatedAddress = newDelegatedEthAddress(/** @type {any} */(signer.address), CoinType.MAIN).toString()
+const wallet = ethers.Wallet.fromPhrase(WALLET_SEED, provider)
+const signer = new ethers.NonceManager(wallet)
+const walletDelegatedAddress = newDelegatedEthAddress(/** @type {any} */(wallet.address), CoinType.MAIN).toString()
 
-console.log('Wallet address:', signer.address, walletDelegatedAddress)
+console.log('Wallet address:', wallet.address, walletDelegatedAddress)
 const ieContractWithSigner = ieContract.connect(signer)
 
 const createPgClient = async () => {
@@ -54,6 +55,7 @@ await Promise.all([
   }),
   startCancelStuckTxs({
     walletDelegatedAddress,
+    address: wallet.address,
     signer
   })
 ])

--- a/lib/cancel-stuck-txs.js
+++ b/lib/cancel-stuck-txs.js
@@ -95,7 +95,7 @@ export async function getRecentSendMessage () {
   return /** @type {any} */(await res.json())
 }
 
-const cancelTx = async ({ tx, signer, recentGasUsed, recentGasFeeCap }) => {
+const cancelTx = async ({ tx, address, signer, recentGasUsed, recentGasFeeCap }) => {
   const oldGasPremium = Number(tx.gasPremium)
   const nonce = tx.nonce
   // Increase by 25% + 1 attoFIL (easier: 25.2%)
@@ -104,7 +104,7 @@ const cancelTx = async ({ tx, signer, recentGasUsed, recentGasFeeCap }) => {
   console.log(`Replacing ${tx.cid}...`)
   try {
     const replacementTx = await signer.sendTransaction({
-      to: signer.address,
+      to: address,
       value: 0,
       nonce,
       gasLimit: Math.ceil(recentGasUsed * 1.1),
@@ -123,7 +123,7 @@ const cancelTx = async ({ tx, signer, recentGasUsed, recentGasFeeCap }) => {
   }
 }
 
-const cancelStuckTxs = async ({ walletDelegatedAddress, signer }) => {
+const cancelStuckTxs = async ({ walletDelegatedAddress, address, signer }) => {
   console.log('Checking for stuck transactions...')
 
   const messages = await getMessagesInMempool(walletDelegatedAddress)
@@ -154,7 +154,7 @@ const cancelStuckTxs = async ({ walletDelegatedAddress, signer }) => {
   const recentGasFeeCap = Number(recentSendMessage.gasFeeCap)
 
   await Promise.all(txsToCancel.map(async tx => {
-    await cancelTx({ tx, signer, recentGasUsed, recentGasFeeCap })
+    await cancelTx({ tx, address, signer, recentGasUsed, recentGasFeeCap })
   }))
 
   return true
@@ -162,6 +162,7 @@ const cancelStuckTxs = async ({ walletDelegatedAddress, signer }) => {
 
 export const startCancelStuckTxs = async ({
   walletDelegatedAddress,
+  address,
   signer
 }) => {
   while (true) {
@@ -169,6 +170,7 @@ export const startCancelStuckTxs = async ({
     try {
       didCancelTxs = await cancelStuckTxs({
         walletDelegatedAddress,
+        address,
         signer
       })
     } catch (err) {


### PR DESCRIPTION
This should help prevent errors like

> spark-evaluate CANNOT SUBMIT SCORES FOR ROUND 14990n (CALL 9/9): Error: nonce has already been used 

As suggested in https://github.com/ethers-io/ethers.js/issues/4258#issuecomment-1705709167