### PR TITLE
fix: refresh DB every 4 hours

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+import ms from 'ms'
 import assert from 'node:assert'
 import * as Sentry from '@sentry/node'
 import { preprocess } from './lib/preprocess.js'
@@ -140,8 +141,8 @@ export const startEvaluate = async ({
     })
   })
 
-  // Update top measurement stations every 12 hours
-  setInterval(() => refreshDatabase(createPgClient), 1000 * 60 * 60 * 12)
+  // Periodically update tables aggregating fine-grained statistics
+  setInterval(() => refreshDatabase(createPgClient), ms('4 hours'))
 
   while (true) {
     await timers.setTimeout(10_000)


### PR DESCRIPTION
I noticed that Spark Public Dashboard does not have data about measurements from yesterday.
https://stats.filspark.com/measurements/daily?from=2024-09-16&to=2024-09-19

```json
[
  {
    "day": "2024-09-16",
    "accepted_measurement_count": 5749452,
    "total_measurement_count": 13084627
  },
  {
    "day": "2024-09-17",
    "accepted_measurement_count": 6155666,
    "total_measurement_count": 14074242
  }
]
```

This data is produced as part of the periodic data aggregation in spark-evaluate:

```js
// Update top measurement stations every 12 hours
setInterval(() => refreshDatabase(createPgClient), 1000 * 60 * 60 * 12)
```

The current 12-hour interval does not work well enough - it’s almost 14 hours since we got complete data for yesterday, and yet our summary tables have not been updated yet.

IMO, it’s time to find a more robust solution for scheduling this job.  Let's keep it easy and just reduce the interval down to 4 hours. It means we will be running redundant SQL queries (especially the update of the materialized view of “top earning participants” is expensive), but other than that, I don’t see any issues.

See the discussion in https://space-meridian.slack.com/archives/C075Q81TGSJ/p1726754510030659
