### PR TITLE
feat: stop populating daily_stations table

### DIFF
--- a/lib/platform-stats.js
+++ b/lib/platform-stats.js
@@ -7,96 +7,12 @@ const debug = createDebug('spark:platform-stats')
 
 /**
  * @param {import('pg').Client} pgClient
- * @param {import('./preprocess.js').Measurement[]} honestMeasurements
  * @param {import('./preprocess.js').Measurement[]} allMeasurements
  */
-export const updatePlatformStats = async (pgClient, honestMeasurements, allMeasurements) => {
+export const updatePlatformStats = async (pgClient, allMeasurements) => {
   const participantsMap = await mapParticipantsToIds(pgClient, new Set(allMeasurements.map(m => m.participantAddress)))
   await updateDailyParticipants(pgClient, Array.from(participantsMap.values()))
-  await updateDailyStationStats(pgClient, honestMeasurements, allMeasurements)
   await updateStationsAndParticipants(pgClient, allMeasurements, participantsMap)
-}
-
-/**
- * @param {import('pg').Client} pgClient
- * @param {import('./preprocess.js').Measurement[]} honestMeasurements
- * @param {import('./preprocess.js').Measurement[]} allMeasurements
- * @param {object} options
- * @param {Date} [options.day]
- */
-export const updateDailyStationStats = async (
-  pgClient,
-  honestMeasurements,
-  allMeasurements,
-  { day = new Date() } = {}
-) => {
-  /** @type{Map<string, {accepted: number, total: number}>} */
-  const statsPerStation = new Map()
-
-  // JSON stringify each compound key to make it comparable, since objects compare by reference
-  /** @type {(m: import('./preprocess.js').Measurement) => string} */
-  const getKey = (m) => JSON.stringify({
-    stationId: m.stationId,
-    participantAddress: m.participantAddress,
-    inet_group: m.inet_group
-  })
-
-  for (const m of honestMeasurements) {
-    if (m.stationId == null) continue
-
-    const key = getKey(m)
-    const stationStats = statsPerStation.get(key) ?? { accepted: 0, total: 0 }
-
-    stationStats.accepted += 1
-    statsPerStation.set(key, stationStats)
-  }
-
-  for (const m of allMeasurements) {
-    if (m.stationId == null) continue
-
-    const key = getKey(m)
-    const stationStats = statsPerStation.get(key) ?? { accepted: 0, total: 0 }
-
-    stationStats.total += 1
-    statsPerStation.set(key, stationStats)
-  }
-
-  debug('Updating daily station stats, station_count=%s', statsPerStation.size)
-
-  // Convert the map to two arrays for the query
-  const keys = Array.from(statsPerStation.keys()).map(k => JSON.parse(k))
-  const values = Array.from(statsPerStation.values())
-
-  await pgClient.query(`
-    INSERT INTO daily_stations (
-      day,
-      station_id,
-      participant_address,
-      inet_group,
-      accepted_measurement_count,
-      total_measurement_count
-    )
-    VALUES (
-      $1::DATE,
-      unnest($2::text[]),
-      unnest($3::text[]),
-      unnest($4::text[]),
-      unnest($5::int[]),
-      unnest($6::int[])
-    )
-    ON CONFLICT (day, station_id, participant_address, inet_group) DO UPDATE
-    SET accepted_measurement_count = daily_stations.accepted_measurement_count
-                                      + EXCLUDED.accepted_measurement_count,
-        total_measurement_count = daily_stations.total_measurement_count
-                                      + EXCLUDED.total_measurement_count
-  `, [
-    day,
-    keys.map(k => k.stationId),
-    keys.map(k => k.participantAddress),
-    keys.map(k => k.inet_group),
-    values.map(v => v.accepted),
-    values.map(v => v.total)
-  ])
 }
 
 /**

--- a/lib/public-stats.js
+++ b/lib/public-stats.js
@@ -38,7 +38,7 @@ export const updatePublicStats = async ({ createPgClient, committees, honestMeas
     }
     await updateIndexerQueryStats(pgClient, committees)
     await updateDailyDealsStats(pgClient, committees, findDealClients)
-    await updatePlatformStats(pgClient, honestMeasurements, allMeasurements)
+    await updatePlatformStats(pgClient, allMeasurements)
   } finally {
     await pgClient.end()
   }


### PR DESCRIPTION
This is the only time-sensitive task remaining in [Fix the performance of the Station Public Dashboard](https://github.com/space-meridian/roadmap/issues/132). The change prevents our PG DB from consuming too much disk space.

I ran `rg daily_stations` in https://github.com/filecoin-station/spark-stats and we are no longer querying that table, so it's safe to stop writing new data.

I am keeping the table around, so that we can use the historical data stored in this table to backfill new tables we created as part of the fix.

Links:
- https://github.com/space-meridian/roadmap/issues/132
