### PR TITLE
fix cancel stuck transactions when previous run not yet finished

### DIFF
--- a/lib/cancel-stuck-transactions.js
+++ b/lib/cancel-stuck-transactions.js
@@ -66,9 +66,9 @@ export const startCancelStuckTransactions = async stuckTransactionsCanceller => 
       }
     })().catch(err => {
       console.error(err)
-        if (err.code !== 'FILFOX_REQUEST_FAILED') {
-          Sentry.captureException(err)
-        }
+      if (err.code !== 'FILFOX_REQUEST_FAILED') {
+        Sentry.captureException(err)
+      }
     })
     await timers.setTimeout(CHECK_STUCK_TXS_DELAY)
   }

--- a/lib/cancel-stuck-transactions.js
+++ b/lib/cancel-stuck-transactions.js
@@ -52,24 +52,26 @@ export const createStuckTransactionsCanceller = ({ pgClient, signer }) => {
 
 export const startCancelStuckTransactions = async stuckTransactionsCanceller => {
   while (true) {
-    try {
-      const res = await stuckTransactionsCanceller.cancelOlderThan(
-        2 * ROUND_LENGTH_MS
-      )
-      if (res !== undefined) {
-        for (const { status, reason } of res) {
-          if (status === 'rejected') {
-            console.error('Failed to cancel transaction:', reason)
-            Sentry.captureException(reason)
+    (async () => {
+      try {
+        const res = await stuckTransactionsCanceller.cancelOlderThan(
+          2 * ROUND_LENGTH_MS
+        )
+        if (res !== undefined) {
+          for (const { status, reason } of res) {
+            if (status === 'rejected') {
+              console.error('Failed to cancel transaction:', reason)
+              Sentry.captureException(reason)
+            }
           }
         }
+      } catch (err) {
+        console.error(err)
+        if (err.code !== 'FILFOX_REQUEST_FAILED') {
+          Sentry.captureException(err)
+        }
       }
-    } catch (err) {
-      console.error(err)
-      if (err.code !== 'FILFOX_REQUEST_FAILED') {
-        Sentry.captureException(err)
-      }
-    }
+    })()
     await timers.setTimeout(CHECK_STUCK_TXS_DELAY)
   }
 }

--- a/lib/cancel-stuck-transactions.js
+++ b/lib/cancel-stuck-transactions.js
@@ -53,25 +53,23 @@ export const createStuckTransactionsCanceller = ({ pgClient, signer }) => {
 export const startCancelStuckTransactions = async stuckTransactionsCanceller => {
   while (true) {
     (async () => {
-      try {
-        const res = await stuckTransactionsCanceller.cancelOlderThan(
-          2 * ROUND_LENGTH_MS
-        )
-        if (res !== undefined) {
-          for (const { status, reason } of res) {
-            if (status === 'rejected') {
-              console.error('Failed to cancel transaction:', reason)
-              Sentry.captureException(reason)
-            }
+      const res = await stuckTransactionsCanceller.cancelOlderThan(
+        2 * ROUND_LENGTH_MS
+      )
+      if (res !== undefined) {
+        for (const { status, reason } of res) {
+          if (status === 'rejected') {
+            console.error('Failed to cancel transaction:', reason)
+            Sentry.captureException(reason)
           }
         }
-      } catch (err) {
-        console.error(err)
+      }
+    })().catch(err => {
+      console.error(err)
         if (err.code !== 'FILFOX_REQUEST_FAILED') {
           Sentry.captureException(err)
         }
-      }
-    })()
+    })
     await timers.setTimeout(CHECK_STUCK_TXS_DELAY)
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@ipld/car": "^5.3.2",
         "@sentry/node": "^8.33.1",
         "@web3-storage/car-block-validator": "^1.2.0",
-        "cancel-stuck-transactions": "^3.0.0",
+        "cancel-stuck-transactions": "^4.0.1",
         "debug": "^4.3.7",
         "drand-client": "^1.2.6",
         "ethers": "^6.13.3",
@@ -1935,9 +1935,10 @@
       }
     },
     "node_modules/cancel-stuck-transactions": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cancel-stuck-transactions/-/cancel-stuck-transactions-3.0.0.tgz",
-      "integrity": "sha512-U/YcVYOXD0gSGR4U1PtXXFhXwZ9r0COc5bIDy6lKri69fxm7L+c4+z/BW4dpRmGnzagMMu3jugxWaZ5CQEbfLA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cancel-stuck-transactions/-/cancel-stuck-transactions-4.0.1.tgz",
+      "integrity": "sha512-vdhUJz+Of96Y+o2RtVjOxp2Twz/zZVaay9tlksph+MoIuXwLwJ4BoI2es2OS31TIXj5Bo37nLNuE9eNqH+7dag==",
+      "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "ms": "^2.1.3"
       }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@ipld/car": "^5.3.2",
     "@sentry/node": "^8.33.1",
     "@web3-storage/car-block-validator": "^1.2.0",
-    "cancel-stuck-transactions": "^3.0.0",
+    "cancel-stuck-transactions": "^4.0.1",
     "debug": "^4.3.7",
     "drand-client": "^1.2.6",
     "ethers": "^6.13.3",


### PR DESCRIPTION
Otherwise while we're stuck waiting for replacement transactions to be confirmed, we're not trying to cancel any new stuck transactions.