### PR TITLE
feat: distinguish HTTP status from Lassie status

### DIFF
--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -250,7 +250,7 @@ const assertValidMeasurement = measurement => {
  * @param {Partial<import('./typings.js').RawMeasurement>} measurement
  * @return {import('./typings.js').RetrievalResult}
  */
-export const getRetrievalResult = measurement => {
+export const getRetrievalResult = (measurement) => {
   switch (measurement.indexer_result) {
     case 'OK':
     case 'HTTP_NOT_ADVERTISED':
@@ -270,8 +270,6 @@ export const getRetrievalResult = measurement => {
   }
 
   switch (measurement.status_code) {
-    case 502: return 'BAD_GATEWAY'
-    case 504: return 'GATEWAY_TIMEOUT'
     case 600: return 'UNKNOWN_FETCH_ERROR'
     case 801: return 'HOSTNAME_DNS_ERROR'
     case 802: return 'CONNECTION_REFUSED'
@@ -281,7 +279,11 @@ export const getRetrievalResult = measurement => {
     case 904: return 'CANNOT_PARSE_CAR_FILE'
   }
 
-  if (measurement.status_code >= 300) return `ERROR_${measurement.status_code}`
+  if (measurement.status_code >= 300) {
+    const prefix = measurement.protocol === 'http' ? 'HTTP_' : 'LASSIE_'
+    // I cannot use + concatenation because TypeScript would complain
+    return `${prefix}${measurement.status_code}`
+  }
 
   const ok = measurement.status_code >= 200 && typeof measurement.end_at === 'string'
 

--- a/lib/retrieval-stats.js
+++ b/lib/retrieval-stats.js
@@ -39,10 +39,7 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
   /** @type {Partial<Record<import('./typings.js').RetrievalResult, number>>} */
   const resultBreakdown = {
     OK: 0,
-    TIMEOUT: 0,
-    CAR_TOO_LARGE: 0,
-    BAD_GATEWAY: 0,
-    GATEWAY_TIMEOUT: 0
+    TIMEOUT: 0
   }
 
   const indexerResultBreakdown = {

--- a/lib/typings.d.ts
+++ b/lib/typings.d.ts
@@ -50,8 +50,6 @@ export type RetrievalResult =
   | 'OK'
   | 'TIMEOUT'
   | 'CAR_TOO_LARGE'
-  | 'BAD_GATEWAY'
-  | 'GATEWAY_TIMEOUT'
   | 'UNKNOWN_FETCH_ERROR'
   | 'UNSUPPORTED_MULTIADDR_FORMAT'
   | 'HOSTNAME_DNS_ERROR'
@@ -62,8 +60,8 @@ export type RetrievalResult =
   | 'CANNOT_PARSE_CAR_FILE'
   | 'IPNI_NOT_QUERIED'
   | `IPNI_${string}`
-  | `ERROR_${number}`
-  | 'ERROR_500'
+  | `HTTP_${number}`
+  | `LASSIE_${number}`
   | 'UNKNOWN_ERROR'
   | CommitteeCheckError
 

--- a/test/committee.test.js
+++ b/test/committee.test.js
@@ -95,7 +95,7 @@ describe('Committee', () => {
       const c = new Committee(VALID_TASK)
       c.addMeasurement({ ...VALID_MEASUREMENT, retrievalResult: 'OK' })
       c.addMeasurement({ ...VALID_MEASUREMENT, retrievalResult: 'IPNI_ERROR_404' })
-      c.addMeasurement({ ...VALID_MEASUREMENT, retrievalResult: 'ERROR_502' })
+      c.addMeasurement({ ...VALID_MEASUREMENT, retrievalResult: 'HTTP_502' })
 
       c.evaluate({ requiredCommitteeSize: 2 })
 

--- a/test/helpers/test-data.js
+++ b/test/helpers/test-data.js
@@ -20,7 +20,7 @@ export const VALID_MEASUREMENT = {
   provider_address: '/dns4/production-ipfs-peer.pinata.cloud/tcp/3000/ws/p2p/Qma8ddFEQWEU8ijWvdxXm3nxU7oHsRtCykAaVz8WUYhiKn',
   providerId: 'PROVIDERID',
   spark_version: '1.10.4',
-  protocol: 'http',
+  protocol: 'bitswap',
   participantAddress: VALID_PARTICIPANT_ADDRESS,
   stationId: VALID_STATION_ID,
   inet_group: VALID_INET_GROUP,

--- a/test/helpers/test-data.js
+++ b/test/helpers/test-data.js
@@ -20,7 +20,7 @@ export const VALID_MEASUREMENT = {
   provider_address: '/dns4/production-ipfs-peer.pinata.cloud/tcp/3000/ws/p2p/Qma8ddFEQWEU8ijWvdxXm3nxU7oHsRtCykAaVz8WUYhiKn',
   providerId: 'PROVIDERID',
   spark_version: '1.10.4',
-  protocol: 'bitswap',
+  protocol: 'http',
   participantAddress: VALID_PARTICIPANT_ADDRESS,
   stationId: VALID_STATION_ID,
   inet_group: VALID_INET_GROUP,

--- a/test/preprocess.js
+++ b/test/preprocess.js
@@ -110,7 +110,7 @@ describe('getRetrievalResult', () => {
     miner_id: 'f1abc',
     provider_address: '/ip4/108.89.91.150/tcp/46717/p2p/12D3KooWSsaFCtzDJUEhLQYDdwoFtdCMqqfk562UMvccFz12kYxU',
     provider_id: 'PROVIDERID',
-    protocol: 'graphsync',
+    protocol: 'http',
     indexer_result: 'OK'
   }
 
@@ -137,36 +137,56 @@ describe('getRetrievalResult', () => {
     assert.strictEqual(result, 'CAR_TOO_LARGE')
   })
 
-  it('BAD_GATEWAY', () => {
+  it('HTTP_502 (Bad Gateway)', () => {
     const result = getRetrievalResult({
       ...SUCCESSFUL_RETRIEVAL,
+      protocol: 'http',
       status_code: 502
     })
-    assert.strictEqual(result, 'BAD_GATEWAY')
+    assert.strictEqual(result, 'HTTP_502')
   })
 
-  it('GATEWAY_TIMEOUT', () => {
+  it('LASSIE_502 (Bad Gateway)', () => {
     const result = getRetrievalResult({
       ...SUCCESSFUL_RETRIEVAL,
-      status_code: 504
+      protocol: 'graphsync',
+      status_code: 502
     })
-    assert.strictEqual(result, 'GATEWAY_TIMEOUT')
+    assert.strictEqual(result, 'LASSIE_502')
   })
 
-  it('SERVER_ERROR - 500', () => {
+  it('HTTP_504 (Gateway Timeout)', () => {
+    const result = getRetrievalResult({
+      ...SUCCESSFUL_RETRIEVAL,
+      protocol: 'http',
+      status_code: 504
+    })
+    assert.strictEqual(result, 'HTTP_504')
+  })
+
+  it('LASSIE_504 (Gateway Timeout)', () => {
+    const result = getRetrievalResult({
+      ...SUCCESSFUL_RETRIEVAL,
+      protocol: 'graphsync',
+      status_code: 504
+    })
+    assert.strictEqual(result, 'LASSIE_504')
+  })
+
+  it('SERVER_ERROR - 500 (over HTTP)', () => {
     const result = getRetrievalResult({
       ...SUCCESSFUL_RETRIEVAL,
       status_code: 500
     })
-    assert.strictEqual(result, 'ERROR_500')
+    assert.strictEqual(result, 'HTTP_500')
   })
 
-  it('SERVER_ERROR - 503', () => {
+  it('SERVER_ERROR - 503 (over HTTP)', () => {
     const result = getRetrievalResult({
       ...SUCCESSFUL_RETRIEVAL,
       status_code: 503
     })
-    assert.strictEqual(result, 'ERROR_503')
+    assert.strictEqual(result, 'HTTP_503')
   })
 
   it('UNKNOWN_ERROR - missing end_at', () => {

--- a/test/public-stats.test.js
+++ b/test/public-stats.test.js
@@ -230,7 +230,7 @@ describe('public-stats', () => {
         // HTTP_NOT_ADVERTISED means the deal is indexed
         { ...VALID_MEASUREMENT, cid: 'bafy2', indexerResult: 'HTTP_NOT_ADVERTISED', retrievalResult: 'IPNI_HTTP_NOT_ADVERTISED' },
         { ...VALID_MEASUREMENT, cid: 'bafy3', indexerResult: 'ERROR_404', retrievalResult: 'IPNI_ERROR_404' },
-        { ...VALID_MEASUREMENT, cid: 'bafy4', status_code: 502, retrievalResult: 'ERROR_502' }
+        { ...VALID_MEASUREMENT, cid: 'bafy4', status_code: 502, retrievalResult: 'HTTP_502' }
       ]
       const allMeasurements = honestMeasurements
       let committees = buildEvaluatedCommitteesFromMeasurements(honestMeasurements)
@@ -254,7 +254,7 @@ describe('public-stats', () => {
       // effectively ignored as the other measurement was successful.
       honestMeasurements.push({ ...VALID_MEASUREMENT, status_code: 502 })
       // These are measurements for a new task.
-      honestMeasurements.push({ ...VALID_MEASUREMENT, cid: 'bafy5', indexerResult: 'OK', status_code: 502, retrievalResult: 'ERROR_502' })
+      honestMeasurements.push({ ...VALID_MEASUREMENT, cid: 'bafy5', indexerResult: 'OK', status_code: 502, retrievalResult: 'HTTP_502' })
       honestMeasurements.push({ ...VALID_MEASUREMENT, cid: 'bafy5', indexerResult: 'UNKNOWN_ERROR', retrievalResult: 'IPNI_UNKNOWN_ERROR' })
       committees = buildEvaluatedCommitteesFromMeasurements(honestMeasurements)
 
@@ -436,20 +436,20 @@ describe('public-stats', () => {
           // a majority is found, retrievalResult = OK
           { ...VALID_MEASUREMENT, retrievalResult: 'OK' },
           { ...VALID_MEASUREMENT, retrievalResult: 'OK' },
-          { ...VALID_MEASUREMENT, retrievalResult: 'ERROR_404' },
+          { ...VALID_MEASUREMENT, retrievalResult: 'HTTP_404' },
 
           // a majority is found, retrievalResult = ERROR_404
           { ...VALID_MEASUREMENT, cid: 'bafy3', retrievalResult: 'OK' },
-          { ...VALID_MEASUREMENT, cid: 'bafy3', retrievalResult: 'ERROR_404' },
-          { ...VALID_MEASUREMENT, cid: 'bafy3', retrievalResult: 'ERROR_404' },
+          { ...VALID_MEASUREMENT, cid: 'bafy3', retrievalResult: 'HTTP_404' },
+          { ...VALID_MEASUREMENT, cid: 'bafy3', retrievalResult: 'HTTP_404' },
 
           // committee is too small
           { ...VALID_MEASUREMENT, cid: 'bafy4', retrievalResult: 'OK' },
 
           // no majority was found
           { ...VALID_MEASUREMENT, cid: 'bafy5', retrievalResult: 'OK' },
-          { ...VALID_MEASUREMENT, cid: 'bafy5', retrievalResult: 'ERROR_404' },
-          { ...VALID_MEASUREMENT, cid: 'bafy5', retrievalResult: 'ERROR_502' }
+          { ...VALID_MEASUREMENT, cid: 'bafy5', retrievalResult: 'HTTP_404' },
+          { ...VALID_MEASUREMENT, cid: 'bafy5', retrievalResult: 'HTTP_502' }
         ]
         honestMeasurements.forEach(m => { m.fraudAssessment = 'OK' })
         const allMeasurements = honestMeasurements
@@ -480,7 +480,7 @@ describe('public-stats', () => {
           { ...VALID_MEASUREMENT, retrievalResult: 'OK' },
 
           // a majority is found, retrievalResult = ERROR_404
-          { ...VALID_MEASUREMENT, cid: 'bafy3', retrievalResult: 'ERROR_404' },
+          { ...VALID_MEASUREMENT, cid: 'bafy3', retrievalResult: 'HTTP_404' },
 
           // committee is too small
           { ...VALID_MEASUREMENT, cid: 'bafy4', retrievalResult: 'OK' }

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -44,7 +44,7 @@ describe('retrieval statistics', () => {
       {
         ...VALID_MEASUREMENT,
         status_code: 500,
-        retrievalResult: 'ERROR_500',
+        retrievalResult: 'HTTP_500',
         indexerResult: 'NO_VALID_ADVERTISEMENT',
         participantAddress: '0xcheater',
         inet_group: 'abcd',
@@ -75,7 +75,7 @@ describe('retrieval statistics', () => {
     assertPointFieldValue(point, 'result_rate_OK', '0.25')
     assertPointFieldValue(point, 'result_rate_TIMEOUT', '0.25')
     assertPointFieldValue(point, 'result_rate_CAR_TOO_LARGE', '0.25')
-    assertPointFieldValue(point, 'result_rate_ERROR_500', '0.25')
+    assertPointFieldValue(point, 'result_rate_HTTP_500', '0.25')
 
     assertPointFieldValue(point, 'ttfb_min', '1000i')
     assertPointFieldValue(point, 'ttfb_mean', '4000i')


### PR DESCRIPTION
Remove the following result codes:
- `ERROR_${number}`
- `BAD_GATEWAY`
- `GATEWAY_TIMEOUT`

Replace them with HTTP status codes prefixed with `HTTP_` if the
retrieval was performed directly over Trustless HTTP GW protocol
and `LASSIE_` if the retrieval was performed using Lassie. In the latter
case, the status code comes from Lassie, not the storage provider.
