### PR TITLE
fix: tighten up indexer result enum

### DIFF
--- a/lib/typings.d.ts
+++ b/lib/typings.d.ts
@@ -61,7 +61,9 @@ export type RetrievalResult =
   | 'UNEXPECTED_CAR_BLOCK'
   | 'CANNOT_PARSE_CAR_FILE'
   | 'IPNI_NOT_QUERIED'
-  | `IPNI_${string}`
+  | 'IPNI_NO_VALID_ADVERTISEMENT'
+  | 'IPNI_ERROR_FETCH'
+  | `IPNI_ERROR_${string}`
   | `ERROR_${number}`
   | 'ERROR_500'
   | 'UNKNOWN_ERROR'
@@ -91,7 +93,15 @@ export interface RawMeasurement {
   byte_length: number;
   car_too_large: boolean;
   car_checksum: string;
-  indexer_result: string | undefined | null;
+  // See https://github.com/filecoin-station/spark/blob/main/lib/ipni-client.js
+  indexer_result:
+    | 'OK'
+    | 'HTTP_NOT_ADVERTISED'
+    | 'NO_VALID_ADVERTISEMENT'
+    | 'ERROR_FETCH'
+    | `ERROR_${number}`
+    | undefined
+    | null;
 }
 
 export type CreatePgClient = () => Promise<import('pg').Client>;

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -665,7 +665,8 @@ describe('fraud detection', function () {
       {
         ...VALID_MEASUREMENT,
         inet_group: 'group1',
-        indexerResult: 'OK'
+        indexerResult:
+        /** @type {const} */('OK')
       },
       {
         ...VALID_MEASUREMENT,

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -665,8 +665,7 @@ describe('fraud detection', function () {
       {
         ...VALID_MEASUREMENT,
         inet_group: 'group1',
-        indexerResult:
-        /** @type {const} */('OK')
+        indexerResult: /** @type {const} */('OK')
       },
       {
         ...VALID_MEASUREMENT,

--- a/test/public-stats.test.js
+++ b/test/public-stats.test.js
@@ -200,9 +200,9 @@ describe('public-stats', () => {
 
       // Notice: this measurement is for the same task as honestMeasurements[0], therefore it's
       // effectively ignored as the other measurement was successful.
-      honestMeasurements.push({ ...VALID_MEASUREMENT, indexerResult: 'UNKNOWN_ERROR' })
+      honestMeasurements.push({ ...VALID_MEASUREMENT, indexerResult: 'ERROR_FETCH' })
       // This is a measurement for a new task.
-      honestMeasurements.push({ ...VALID_MEASUREMENT, cid: 'bafy4', indexerResult: 'UNKNOWN_ERROR' })
+      honestMeasurements.push({ ...VALID_MEASUREMENT, cid: 'bafy4', indexerResult: 'ERROR_FETCH' })
       committees = buildEvaluatedCommitteesFromMeasurements(honestMeasurements)
 
       await updatePublicStats({
@@ -228,7 +228,7 @@ describe('public-stats', () => {
       const honestMeasurements = [
         { ...VALID_MEASUREMENT },
         // HTTP_NOT_ADVERTISED means the deal is indexed
-        { ...VALID_MEASUREMENT, cid: 'bafy2', indexerResult: 'HTTP_NOT_ADVERTISED', retrievalResult: 'IPNI_HTTP_NOT_ADVERTISED' },
+        { ...VALID_MEASUREMENT, cid: 'bafy2', indexerResult: 'HTTP_NOT_ADVERTISED', retrievalResult: 'ERROR_502' },
         { ...VALID_MEASUREMENT, cid: 'bafy3', indexerResult: 'ERROR_404', retrievalResult: 'IPNI_ERROR_404' },
         { ...VALID_MEASUREMENT, cid: 'bafy4', status_code: 502, retrievalResult: 'ERROR_502' }
       ]
@@ -255,7 +255,7 @@ describe('public-stats', () => {
       honestMeasurements.push({ ...VALID_MEASUREMENT, status_code: 502 })
       // These are measurements for a new task.
       honestMeasurements.push({ ...VALID_MEASUREMENT, cid: 'bafy5', indexerResult: 'OK', status_code: 502, retrievalResult: 'ERROR_502' })
-      honestMeasurements.push({ ...VALID_MEASUREMENT, cid: 'bafy5', indexerResult: 'UNKNOWN_ERROR', retrievalResult: 'IPNI_UNKNOWN_ERROR' })
+      honestMeasurements.push({ ...VALID_MEASUREMENT, cid: 'bafy5', indexerResult: 'ERROR_FETCH', retrievalResult: 'IPNI_ERROR_FETCH' })
       committees = buildEvaluatedCommitteesFromMeasurements(honestMeasurements)
 
       await updatePublicStats({
@@ -312,7 +312,7 @@ describe('public-stats', () => {
       {
         /** @type {Measurement[]} */
         const honestMeasurements = [
-          { ...VALID_MEASUREMENT, cid: 'bafy5', indexerResult: 'UNKNOWN_ERROR', retrievalResult: 'IPNI_UNKNOWN_ERROR' }
+          { ...VALID_MEASUREMENT, cid: 'bafy5', indexerResult: 'ERROR_FETCH', retrievalResult: 'IPNI_ERROR_FETCH' }
         ]
         const allMeasurements = honestMeasurements
         const committees = buildEvaluatedCommitteesFromMeasurements(honestMeasurements)


### PR DESCRIPTION
Change the `string` type to an enum with the following variants:

    | 'OK'
    | 'HTTP_NOT_ADVERTISED'
    | 'NO_VALID_ADVERTISEMENT'
    | 'ERROR_FETCH'
    | `ERROR_${number}`
    | undefined
    | null;
