### PR TITLE
ie-contract: Disable JSON-RPC polling

### DIFF
--- a/lib/contracts.js
+++ b/lib/contracts.js
@@ -16,7 +16,6 @@ export const createContracts = (ieContractAddress = SparkImpactEvaluator.ADDRESS
     const fetchRequest = new ethers.FetchRequest(url)
     fetchRequest.setHeader('Authorization', `Bearer ${GLIF_TOKEN}`)
     return new ethers.JsonRpcProvider(fetchRequest, null, {
-      polling: true,
       batchMaxCount: 10
     })
   }))


### PR DESCRIPTION
This makes us use eth_getFilterChanges which should now work. If it doesn't, this will let us give feedback.

See also https://github.com/filecoin-station/spark-api/pull/451