### PR TITLE
cli: split `fetch-recent-miner-measurements` and `evaluate-measurements`

### DIFF
--- a/bin/evaluate-measurements.js
+++ b/bin/evaluate-measurements.js
@@ -36,10 +36,13 @@ for (const line of measurementsFile.split('\n').filter(Boolean)) {
   rounds.get(roundIndex).push(measurement)
 }
 
-const EVALUATION_FILE = `${basename(measurementsPath, '.ndjson')}.evaluation.txt`
-const evaluationWriter = fs.createWriteStream(EVALUATION_FILE)
+const EVALUATION_TXT_FILE = `${basename(measurementsPath, '.ndjson')}.evaluation.txt`
+const EVALUATION_NDJSON_FILE = `${basename(measurementsPath, '.ndjson')}.evaluation.ndjson`
 
-evaluationWriter.write(formatHeader({ includeFraudAssesment: keepRejected }) + '\n')
+const evaluationTxtWriter = fs.createWriteStream(EVALUATION_TXT_FILE)
+const evaluationNdjsonWriter = fs.createWriteStream(EVALUATION_NDJSON_FILE)
+
+evaluationTxtWriter.write(formatHeader({ includeFraudAssesment: keepRejected }) + '\n')
 
 const resultCounts = {
   total: 0
@@ -63,7 +66,8 @@ for (const [r, c] of Object.entries(resultCounts)) {
   )
 }
 
-console.error('Wrote evaluation to %s', EVALUATION_FILE)
+console.error('Wrote   human-readable evaluation to %s', EVALUATION_TXT_FILE)
+console.error('Wrote machine-readable evaluation to %s', EVALUATION_NDJSON_FILE)
 
 /**
  * @param {bigint} roundIndex
@@ -107,9 +111,14 @@ async function processRound (roundIndex, measurements, resultCounts) {
       .map(m => ({ ...m, fraudAssessment: undefined }))
   }
 
-  evaluationWriter.write(
+  evaluationTxtWriter.write(
     round.measurements
       .map(m => formatMeasurement(m, { includeFraudAssesment: keepRejected }) + '\n')
+      .join('')
+  )
+  evaluationNdjsonWriter.write(
+    round.measurements
+      .map(m => JSON.stringify(m) + '\n')
       .join('')
   )
   console.error(' → added %s accepted measurements from this round', round.measurements.length)

--- a/bin/evaluate-measurements.js
+++ b/bin/evaluate-measurements.js
@@ -1,0 +1,176 @@
+import fs from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { RoundData } from '../lib/round.js'
+import { evaluate } from '../lib/evaluate.js'
+import * as SparkImpactEvaluator from '@filecoin-station/spark-impact-evaluator'
+import { fetchRoundDetails } from '../lib/spark-api.js'
+import createDebug from 'debug'
+import { Point } from '@influxdata/influxdb-client'
+import { createHash } from 'node:crypto'
+
+const { KEEP_REJECTED } = process.env
+
+const debug = createDebug('spark:bin')
+
+const [nodePath, selfPath, measurementsPath] = process.argv
+
+const USAGE = `
+Usage:
+  ${nodePath} ${selfPath} measurementsPath
+`
+
+if (!measurementsPath) {
+  console.error('Missing required argument: measurementsPath')
+  console.error(USAGE)
+  process.exit(1)
+}
+
+const keepRejected = isFlagEnabled(KEEP_REJECTED)
+
+const rounds = new Map()
+const measurementsFile = await readFile(measurementsPath, 'utf8')
+for (const line of measurementsFile.split('\n').filter(Boolean)) {
+  const { roundIndex: _roundIndex, measurement } = JSON.parse(line)
+  const roundIndex = BigInt(_roundIndex)
+  if (!rounds.has(roundIndex)) rounds.set(roundIndex, [])
+  rounds.get(roundIndex).push(measurement)
+}
+
+const EVALUATION_FILE = `evaluation-${
+  createHash('sha256').update(measurementsFile).digest('hex').substring(0, 7)
+}.txt`
+const evaluationWriter = fs.createWriteStream(EVALUATION_FILE)
+
+evaluationWriter.write(formatHeader({ includeFraudAssesment: keepRejected }) + '\n')
+
+const resultCounts = {
+  total: 0
+}
+
+for (const [roundIndex, measurements] of rounds) {
+  await processRound(
+    roundIndex,
+    measurements,
+    resultCounts
+  )
+}
+
+console.log('Found %s accepted measurements.', resultCounts.total)
+for (const [r, c] of Object.entries(resultCounts)) {
+  if (r === 'total') continue
+  console.log('  %s %s (%s%)',
+    r.padEnd(40),
+    String(c).padEnd(10),
+    Math.floor(c / resultCounts.total * 10000) / 100
+  )
+}
+
+console.error('Wrote evaluation to %s', EVALUATION_FILE)
+
+/**
+ * @param {bigint} roundIndex
+ * @param {object[]} measurements
+ * @param {Record<string, number>} resultCounts
+ */
+async function processRound (roundIndex, measurements, resultCounts) {
+  console.error(' → evaluating round %s', roundIndex)
+
+  const round = new RoundData(roundIndex)
+  round.measurements = measurements
+
+  const ieContract = {
+    async getAddress () {
+      return SparkImpactEvaluator.ADDRESS
+    }
+  }
+
+  await evaluate({
+    roundIndex: round.index,
+    round,
+    fetchRoundDetails,
+    recordTelemetry,
+    logger: { log: debug, error: debug },
+    ieContract,
+    setScores: async () => {},
+    prepareProviderRetrievalResultStats: async () => {}
+  })
+
+  for (const m of round.measurements) {
+    if (m.fraudAssessment !== 'OK') continue
+    resultCounts.total++
+    resultCounts[m.retrievalResult] = (resultCounts[m.retrievalResult] ?? 0) + 1
+  }
+
+  if (!keepRejected) {
+    round.measurements = round.measurements
+      // Keep accepted measurements only
+      .filter(m => m.fraudAssessment === 'OK')
+      // Remove the fraudAssessment field as all accepted measurements have the same 'OK' value
+      .map(m => ({ ...m, fraudAssessment: undefined }))
+  }
+
+  evaluationWriter.write(
+    round.measurements
+      .map(m => formatMeasurement(m, { includeFraudAssesment: keepRejected }) + '\n')
+      .join('')
+  )
+  console.error(' → added %s accepted measurements from this round', round.measurements.length)
+}
+
+/**
+ * @param {string} measurementName
+ * @param {(point: Point) => void} fn
+ */
+function recordTelemetry (measurementName, fn) {
+  const point = new Point(measurementName)
+  fn(point)
+  debug('TELEMETRY %s %o', measurementName, point.fields)
+}
+
+/**
+ * @param {string | undefined} envVarValue
+ */
+function isFlagEnabled (envVarValue) {
+  return !!envVarValue && envVarValue.toLowerCase() !== 'false' && envVarValue !== '0'
+}
+
+/**
+ * @param {import('../lib/preprocess.js').Measurement} m
+ * @param {object} options
+ * @param {boolean} [options.includeFraudAssesment]
+ */
+function formatMeasurement (m, { includeFraudAssesment } = {}) {
+  const fields = [
+    new Date(m.finished_at).toISOString(),
+    (m.cid ?? '').padEnd(70),
+    (m.protocol ?? '').padEnd(10)
+  ]
+
+  if (includeFraudAssesment) {
+    fields.push((m.fraudAssessment === 'OK' ? '🫡  ' : '🙅  '))
+  }
+
+  fields.push((m.retrievalResult ?? ''))
+
+  return fields.join(' ')
+}
+
+/**
+ * @param {object} options
+ * @param {boolean} [options.includeFraudAssesment]
+ */
+function formatHeader ({ includeFraudAssesment } = {}) {
+  const fields = [
+    'Timestamp'.padEnd(new Date().toISOString().length),
+    'CID'.padEnd(70),
+    'Protocol'.padEnd(10)
+  ]
+
+  if (includeFraudAssesment) {
+    fields.push('🕵️  ')
+  }
+
+  fields.push('RetrievalResult')
+
+  return fields.join(' ')
+}

--- a/bin/evaluate-measurements.js
+++ b/bin/evaluate-measurements.js
@@ -36,7 +36,7 @@ for (const line of measurementsFile.split('\n').filter(Boolean)) {
   rounds.get(roundIndex).push(measurement)
 }
 
-const EVALUATION_FILE = `${basename(measurementsPath)}.evaluation.txt`
+const EVALUATION_FILE = `${basename(measurementsPath, '.ndjson')}.evaluation.txt`
 const evaluationWriter = fs.createWriteStream(EVALUATION_FILE)
 
 evaluationWriter.write(formatHeader({ includeFraudAssesment: keepRejected }) + '\n')

--- a/bin/evaluate-measurements.js
+++ b/bin/evaluate-measurements.js
@@ -6,7 +6,7 @@ import * as SparkImpactEvaluator from '@filecoin-station/spark-impact-evaluator'
 import { fetchRoundDetails } from '../lib/spark-api.js'
 import createDebug from 'debug'
 import { Point } from '@influxdata/influxdb-client'
-import { createHash } from 'node:crypto'
+import { basename } from 'node:path'
 
 const { KEEP_REJECTED } = process.env
 
@@ -36,9 +36,7 @@ for (const line of measurementsFile.split('\n').filter(Boolean)) {
   rounds.get(roundIndex).push(measurement)
 }
 
-const EVALUATION_FILE = `evaluation-${
-  createHash('sha256').update(measurementsFile).digest('hex').substring(0, 7)
-}.txt`
+const EVALUATION_FILE = `${basename(measurementsPath)}.evaluation.txt`
 const evaluationWriter = fs.createWriteStream(EVALUATION_FILE)
 
 evaluationWriter.write(formatHeader({ includeFraudAssesment: keepRejected }) + '\n')


### PR DESCRIPTION
Usage:

```console
$ node bin/fetch-recent-miner-measurements.js f0...
...
$ node bin/evaluate-measurements measurements-f0....ndjson
 → evaluating round 19117n
 → added 183 accepted measurements from this round
 → evaluating round 19118n
 → added 0 accepted measurements from this round
 → evaluating round 19127n
 → added 181 accepted measurements from this round
 → evaluating round 19128n
 → added 0 accepted measurements from this round
Found 364 accepted measurements.
  IPNI_ERROR_404                           364        (100%)
Wrote evaluation to evaluation-5bf6db8.txt
```

This is a first step towards evaluating arbitrary rounds. Next: https://github.com/filecoin-station/spark-evaluate/pull/402

__After merging, update Spark troubleshooting docs__