### PR TITLE
feat: metric for successful http retrievals

### DIFF
--- a/lib/retrieval-stats.js
+++ b/lib/retrieval-stats.js
@@ -58,6 +58,7 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
   const ttfbValues = []
   const durationValues = []
   const sizeValues = []
+  let httpSuccesses = 0
 
   for (const m of measurements) {
     // `retrievalResult` should be always set by lib/preprocess.js, so we should never encounter
@@ -99,11 +100,16 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
     const taskId = getTaskId(m)
     if (m.indexerResult) tasksWithIndexerResults.add(taskId)
     if (m.indexerResult === 'OK') tasksWithHttpAdvertisement.add(taskId)
+
+    // A successful HTTP response is a response with status code 200 and the protocol being used is set to HTTP.
+    if (m.retrievalResult === 'OK' && m.protocol.toLowerCase() === 'http') { httpSuccesses++ }
   }
   const successRate = resultBreakdown.OK / totalCount
-
+  const successRateHttp = httpSuccesses / totalCount
+  console.log('successRateHttp', successRateHttp)
   telemetryPoint.intField('unique_tasks', uniqueTasksCount)
   telemetryPoint.floatField('success_rate', successRate)
+  telemetryPoint.floatField('success_rate_http', successRateHttp)
   telemetryPoint.intField('participants', participants.size)
   telemetryPoint.intField('inet_groups', inetGroups.size)
   telemetryPoint.intField('measurements', totalCount)

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -322,6 +322,7 @@ describe('evaluate', async function () {
     assertPointFieldValue(point, 'measurements', '1i')
     assertPointFieldValue(point, 'unique_tasks', '1i')
     assertPointFieldValue(point, 'success_rate', '1')
+    assertPointFieldValue(point, 'success_rate_http', '0')
 
     point = telemetry.find(p => p.name === 'retrieval_stats_all')
     assert(!!point,
@@ -329,6 +330,7 @@ describe('evaluate', async function () {
     assertPointFieldValue(point, 'measurements', '10i')
     assertPointFieldValue(point, 'unique_tasks', '2i')
     assertPointFieldValue(point, 'success_rate', '0.5')
+    assertPointFieldValue(point, 'success_rate_http', '0')
   })
 
   it('prepares provider retrieval result stats', async () => {

--- a/test/retrieval-stats.test.js
+++ b/test/retrieval-stats.test.js
@@ -19,7 +19,8 @@ describe('retrieval statistics', () => {
     /** @type {Measurement[]} */
     const measurements = [
       {
-        ...VALID_MEASUREMENT
+        ...VALID_MEASUREMENT,
+        protocol: 'http'
       },
       {
         ...VALID_MEASUREMENT,
@@ -31,7 +32,8 @@ describe('retrieval statistics', () => {
         first_byte_at: new Date('2023-11-01T09:00:10.000Z').getTime(),
         end_at: new Date('2023-11-01T09:00:50.000Z').getTime(),
         finished_at: new Date('2023-11-01T09:00:30.000Z').getTime(),
-        byte_length: 2048
+        byte_length: 2048,
+        protocol: 'http'
       },
       {
         ...VALID_MEASUREMENT,
@@ -57,7 +59,7 @@ describe('retrieval statistics', () => {
         // invalid task
         cid: 'bafyinvalid',
         provider_address: '/dns4/production-ipfs-peer.pinata.cloud/tcp/3000/ws/p2p/Qma8ddFEQWEU8ijWvdxXm3nxU7oHsRtCykAaVz8WUYhiKn',
-        protocol: 'bitswap'
+        protocol: 'http'
       }
     ]
 
@@ -68,6 +70,8 @@ describe('retrieval statistics', () => {
     assertPointFieldValue(point, 'measurements', '4i')
     assertPointFieldValue(point, 'unique_tasks', '3i')
     assertPointFieldValue(point, 'success_rate', '0.25')
+    assertPointFieldValue(point, 'success_rate_http', '0.25')
+    assertPointFieldValue(point, 'participants', '2i')
     assertPointFieldValue(point, 'participants', '2i')
     assertPointFieldValue(point, 'inet_groups', '2i')
     assertPointFieldValue(point, 'download_bandwidth', '209718272i')


### PR DESCRIPTION
This MR proposes the following changes: 

1. Add a metric for counting the successful http retrievals

Following the definition of a this [issue](https://github.com/space-meridian/roadmap/issues/192#issue-2668841168)  the metric is defined as:

> how many retrievals succeeded using HTTP protocol for CAR transfer. (A retrieval that had to use Graphsync because the SP does not advertise HTTP is considered as a failure.)

In practice a successful http request is indicated by `Measurement.retrievalResult`  as well as the protocol being used indicated by`Measurement.protocol`. 