### PR TITLE
feat: assert indexer_result during preprocessing

### DIFF
--- a/lib/evaluate.js
+++ b/lib/evaluate.js
@@ -268,15 +268,6 @@ export const runFraudDetection = async ({
   )
 
   //
-  // 0. Filter out measurements missing required fields.
-  //
-  for (const m of measurements) {
-    if (!m.indexerResult) {
-      m.fraudAssessment = 'IPNI_NOT_QUERIED'
-    }
-  }
-
-  //
   // 1. Filter out measurements not belonging to any valid task in this round
   //    or missing some of the required fields like `inet_group`
   //

--- a/lib/preprocess.js
+++ b/lib/preprocess.js
@@ -230,7 +230,7 @@ export const parseParticipantAddress = filWalletAddress => {
 /**
  * @param {Measurement} measurement
  */
-const assertValidMeasurement = measurement => {
+export const assertValidMeasurement = measurement => {
   assert(
     typeof measurement === 'object' && measurement !== null,
     'object required'
@@ -238,6 +238,7 @@ const assertValidMeasurement = measurement => {
   assert(ethers.isAddress(measurement.participantAddress), 'valid participant address required')
   assert(typeof measurement.inet_group === 'string', 'valid inet group required')
   assert(typeof measurement.finished_at === 'number', 'field `finished_at` must be set to a number')
+  assert(measurement.indexerResult, 'field `indexerResult` must be set')
   if (measurement.stationId) {
     assert(
       typeof measurement.stationId === 'string' &&
@@ -256,9 +257,6 @@ export const getRetrievalResult = (measurement) => {
     case 'OK':
     case 'HTTP_NOT_ADVERTISED':
       break
-    case undefined:
-    case null:
-      return 'IPNI_NOT_QUERIED'
     default:
       return `IPNI_${measurement.indexer_result}`
   }

--- a/lib/typings.d.ts
+++ b/lib/typings.d.ts
@@ -41,7 +41,6 @@ export type FraudAssesment =
   | 'TASK_WRONG_NODE'
   | 'DUP_INET_GROUP'
   | 'TOO_MANY_TASKS'
-  | 'IPNI_NOT_QUERIED'
   | CommitteeCheckError
 
 
@@ -58,7 +57,6 @@ export type RetrievalResult =
   | 'CONTENT_VERIFICATION_FAILED'
   | 'UNEXPECTED_CAR_BLOCK'
   | 'CANNOT_PARSE_CAR_FILE'
-  | 'IPNI_NOT_QUERIED'
   | 'IPNI_NO_VALID_ADVERTISEMENT'
   | 'IPNI_ERROR_FETCH'
   | `IPNI_ERROR_${number}`
@@ -97,9 +95,7 @@ export interface RawMeasurement {
     | 'HTTP_NOT_ADVERTISED'
     | 'NO_VALID_ADVERTISEMENT'
     | 'ERROR_FETCH'
-    | `ERROR_${number}`
-    | undefined
-    | null;
+    | `ERROR_${number}`;
 }
 
 export type CreatePgClient = () => Promise<import('pg').Client>;

--- a/test/evaluate.js
+++ b/test/evaluate.js
@@ -695,45 +695,6 @@ describe('fraud detection', function () {
     )
   })
 
-  it('rejects measurements missing indexer result', async () => {
-    /** @type {RoundDetails} */
-    const sparkRoundDetails = {
-      ...SPARK_ROUND_DETAILS,
-      retrievalTasks: [
-        {
-          cid: VALID_MEASUREMENT.cid,
-          minerId: 'f1test'
-        }
-      ]
-    }
-
-    const measurements = [
-      {
-        ...VALID_MEASUREMENT,
-        inet_group: 'group1',
-        indexerResult: /** @type {const} */('OK')
-      },
-      {
-        ...VALID_MEASUREMENT,
-        inet_group: 'group2',
-        indexerResult: undefined
-      }
-    ]
-
-    await runFraudDetection({
-      roundIndex: 1n,
-      measurements,
-      sparkRoundDetails,
-      requiredCommitteeSize: 1,
-      logger
-    })
-
-    assert.deepStrictEqual(
-      measurements.map(m => m.fraudAssessment),
-      ['OK', 'IPNI_NOT_QUERIED']
-    )
-  })
-
   it('rejects tasks not allowed by the tasking algorithm', async () => {
     /** @type {RoundDetails} */
     const sparkRoundDetails = {


### PR DESCRIPTION
Move the validation step earlier to the preprocess/evaluate pipeline.  Measurements missing the indexer result are dropped as invalid.

This is the first step to refactor `fraudAssessment` field for more clarity, see https://github.com/filecoin-station/spark-evaluate/pull/396#discussion_r1850597708
