### PR TITLE
refactor: remove redundant protocol.toLowerCase()

### DIFF
--- a/lib/retrieval-stats.js
+++ b/lib/retrieval-stats.js
@@ -102,7 +102,7 @@ export const buildRetrievalStats = (measurements, telemetryPoint) => {
     if (m.indexerResult === 'OK') tasksWithHttpAdvertisement.add(taskId)
 
     // A successful HTTP response is a response with result breakdown set to OK and the protocol being used is set to HTTP.
-    if (m.retrievalResult === 'OK' && m.protocol.toLowerCase() === 'http') { httpSuccesses++ }
+    if (m.retrievalResult === 'OK' && m.protocol === 'http') { httpSuccesses++ }
   }
   const successRate = resultBreakdown.OK / totalCount
   const successRateHttp = httpSuccesses / totalCount


### PR DESCRIPTION
The protocol string is normalized to lower-case by Measurements constructor, see 3ac022a.
