### PR TITLE
chore: fix TypeScript error

### DIFF
--- a/lib/storacha.js
+++ b/lib/storacha.js
@@ -3,7 +3,14 @@ import { ed25519 } from '@ucanto/principal'
 import { CarReader } from '@ipld/car'
 import { importDAG } from '@ucanto/core/delegation'
 
+/**
+ * @param {string} data
+ */
 async function parseProof (data) {
+  // Casting to unsafe `any[]` to avoid the following TypeScript error:
+  //    Argument of type 'Block[]' is not assignable to parameter
+  //    of type 'Iterable<Block<unknown, number, number, 1>>'
+  /** @type {any[]} */
   const blocks = []
   const reader = await CarReader.fromBytes(Buffer.from(data, 'base64'))
   for await (const block of reader.blocks()) {


### PR DESCRIPTION
Fix the following error:

```
lib/storacha.js:12:20 - error TS2345: Argument of type 'Block[]' is not assignable to parameter of type 'Iterable<Block<unknown, number, number, 1>>'.
  The types returned by '[Symbol.iterator]().next(...)' are incompatible between these types.
    Type 'IteratorResult<Block, any>' is not assignable to type 'IteratorResult<Block<unknown, number, number, 1>, any>'.
      Type 'IteratorYieldResult<Block>' is not assignable to type 'IteratorResult<Block<unknown, number, number, 1>, any>'.
        Type 'IteratorYieldResult<Block>' is not assignable to type 'IteratorYieldResult<Block<unknown, number, number, 1>>'.
          Type 'Block' is not assignable to type 'Block<unknown, number, number, 1>'.
            The types of 'cid.version' are incompatible between these types.
              Type 'Version' is not assignable to type '1'.
                Type '0' is not assignable to type '1'.

12   return importDAG(blocks)
```
